### PR TITLE
10 separate calculations into each class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED True)
 
 # main executable
-add_executable(${PROJECT_NAME} 
+add_executable(${PROJECT_NAME}
   src/bucket.cpp
   src/loader.cpp
   src/main.cpp
@@ -15,6 +15,7 @@ add_executable(${PROJECT_NAME}
   src/saver.cpp
   src/simulation.cpp
   src/weight.cpp
+  src/pressure_calculator/implicit.cpp
 )
 
 # OpenMP
@@ -42,7 +43,7 @@ FetchContent_MakeAvailable(googletest)
 enable_testing()
 add_executable(
     mps_test
-    src/refvalues.cpp  
+    src/refvalues.cpp
     test/refvalues_test.cpp
     src/weight.cpp
     test/weight_test.cpp

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,8 @@ FetchContent_MakeAvailable(googletest)
 enable_testing()
 add_executable(
     mps_test
-    # src/refvalues.cpp
-    # test/refvalues_test.cpp
+    src/refvalues.cpp
+    test/refvalues_test.cpp
     src/weight.cpp
     test/weight_test.cpp
 )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,8 +43,8 @@ FetchContent_MakeAvailable(googletest)
 enable_testing()
 add_executable(
     mps_test
-    src/refvalues.cpp
-    test/refvalues_test.cpp
+    # src/refvalues.cpp
+    # test/refvalues_test.cpp
     src/weight.cpp
     test/weight_test.cpp
 )

--- a/scripts/mac.sh
+++ b/scripts/mac.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# Shebang: The first row is for running the script with bash, not other shell like sh
+
+# go to root directory so that we can activate the script from any directory
+cd $(dirname $0)/..
+
+mkdir -p result/dambreak/ # remove all folders/files in result/dambreak
+rm -rf result/dambreak/* # remove all folders/files in result/dambreak
+./build/mps input/dambreak/settings.yml 2> result/dambreak/error.log | tee result/dambreak/console.log # run simulation

--- a/src/mps.cpp
+++ b/src/mps.cpp
@@ -6,7 +6,7 @@
 using std::cerr;
 using std::endl;
 
-MPS::MPS(const Input& input, std::unique_ptr<IPressureCalculator> pressureCalculator) {
+MPS::MPS(const Input& input, std::unique_ptr<IPressureCalculator>&& pressureCalculator) {
 	this->settings           = input.settings;
 	this->domain             = input.settings.domain;
 	this->particles          = input.particles;

--- a/src/mps.cpp
+++ b/src/mps.cpp
@@ -6,7 +6,7 @@
 using std::cerr;
 using std::endl;
 
-MPS::MPS(const Input& input, std::unique_ptr<IPressureCalculator>&& pressureCalculator) {
+MPS::MPS(const Input& input, std::unique_ptr<PressureCalculator::Interface>&& pressureCalculator) {
 	this->settings           = input.settings;
 	this->domain             = input.settings.domain;
 	this->particles          = input.particles;

--- a/src/mps.cpp
+++ b/src/mps.cpp
@@ -6,10 +6,11 @@
 using std::cerr;
 using std::endl;
 
-MPS::MPS(const Input& input) {
+MPS::MPS(const Input& input, std::unique_ptr<IPressureCalculator> pressureCalculator) {
 	this->settings  = input.settings;
 	this->domain    = input.settings.domain;
 	this->particles = input.particles;
+	this->pressureCalculator = std::move(pressureCalculator);
 }
 
 void MPS::init() {
@@ -31,7 +32,9 @@ void MPS::stepForward() {
 
 	bucket.storeParticles(particles, domain);
 	setNeighbors(settings.reMax);
-	calPressure();
+	calNumberDensity(settings.re_forNumberDensity);
+	setBoundaryCondition();
+	pressureCalculator->calc(particles);
 	calPressureGradient(settings.re_forGradient);
 	moveParticleUsingPressureGradient();
 
@@ -124,6 +127,7 @@ void MPS::collision() {
 		}
 	}
 }
+
 void MPS::calNumberDensity(const double& re) {
 #pragma omp parallel for
 	for (auto& pi : particles) {
@@ -136,6 +140,7 @@ void MPS::calNumberDensity(const double& re) {
 			pi.numberDensity += weight(neighbor.distance, re);
 	}
 }
+
 void MPS::setBoundaryCondition() {
 	double n0   = refValues.n0_forNumberDensity;
 	double beta = settings.surfaceDetectionRatio;
@@ -150,143 +155,6 @@ void MPS::setBoundaryCondition() {
 
 		} else {
 			pi.boundaryCondition = FluidState::Inner;
-		}
-	}
-}
-
-void MPS::setSourceTerm() {
-	double n0    = refValues.n0_forNumberDensity;
-	double gamma = settings.relaxationCoefficientForPressure;
-
-#pragma omp parallel for
-	for (auto& pi : particles) {
-		pi.sourceTerm = 0.0;
-		if (pi.boundaryCondition == FluidState::Inner) {
-			pi.sourceTerm = gamma * (1.0 / (settings.dt * settings.dt)) * ((pi.numberDensity - n0) / n0);
-		}
-	}
-}
-
-void MPS::setMatrix(const double& re) {
-	std::vector<Eigen::Triplet<double>> triplets;
-	auto n0 = refValues.n0_forLaplacian;
-	auto a  = 2.0 * settings.dim / (n0 * refValues.lambda);
-	coefficientMatrix.resize(particles.size(), particles.size());
-
-	for (auto& pi : particles) {
-		if (pi.boundaryCondition != FluidState::Inner)
-			continue;
-
-		double coefficient_ii = 0.0;
-		for (auto& neighbor : pi.neighbors) {
-			Particle& pj = particles[neighbor.id];
-			if (pj.boundaryCondition == FluidState::Ignored)
-				continue;
-
-			if (neighbor.distance < re) {
-				double coefficient_ij = a * weight(neighbor.distance, re) / settings.fluidDensity;
-				triplets.emplace_back(pi.id, pj.id, -1.0 * coefficient_ij);
-				coefficient_ii += coefficient_ij;
-			}
-		}
-		coefficient_ii += (settings.compressibility) / (settings.dt * settings.dt);
-		triplets.emplace_back(pi.id, pi.id, coefficient_ii);
-	}
-	coefficientMatrix.setFromTriplets(triplets.begin(), triplets.end());
-
-	// exceptionalProcessingForBoundaryCondition();
-}
-void MPS::exceptionalProcessingForBoundaryCondition() {
-	std::vector<bool> checked(particles.size(), false);
-	std::vector<bool> connected(particles.size(), false);
-
-	for (auto& pi : particles) {
-		if (pi.boundaryCondition == FluidState::FreeSurface)
-			connected[pi.id] = true;
-		if (connected[pi.id])
-			continue;
-		// BFS for connected components
-		std::queue<size_t> queue;
-		queue.push(pi.id);
-		checked[pi.id] = true;
-		while (!queue.empty()) {
-			// pop front element
-			auto v = queue.front();
-			queue.pop();
-			// search for adjacent nodes
-			for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(coefficientMatrix, v); it; ++it) {
-				auto nv = it.col();
-				if (!checked[nv]) {
-					if (connected[nv]) { // connected to boundary
-						connected[v] = true;
-						checked[v]   = true;
-						break;
-
-					} else {
-						queue.push(nv);
-						checked[nv] = true;
-					}
-				}
-			}
-		}
-	}
-}
-
-void MPS::solveSimultaneousEquations() {
-	sourceTerm.resize(particles.size());
-	pressure.resize(particles.size());
-
-#pragma omp parallel for
-	for (auto& pi : particles) {
-		sourceTerm[pi.id] = pi.sourceTerm;
-	}
-
-	Eigen::BiCGSTAB<Eigen::SparseMatrix<double, Eigen::RowMajor>> solver;
-	solver.compute(coefficientMatrix);
-	pressure = solver.solve(sourceTerm);
-	if (solver.info() != Eigen::Success) {
-		cerr << "Pressure calculation failed." << endl;
-		std::exit(-1);
-	}
-
-#pragma omp parallel for
-	for (auto& pi : particles) {
-		pi.pressure = pressure[pi.id];
-	}
-}
-void MPS::removeNegativePressure() {
-#pragma omp parallel for
-	for (auto& p : particles) {
-		if (p.pressure < 0.0) {
-			p.pressure = 0.0;
-		}
-	}
-}
-/**
- * @brief set minimum pressure for pressure gradient calculation
- * @param re effective radius \f$r_e\f$
- */
-void MPS::setMinimumPressure(const double& re) {
-#pragma omp parallel for
-	for (auto& p : particles) {
-		p.minimumPressure = p.pressure;
-	}
-
-	for (auto& pi : particles) {
-		if (pi.type == ParticleType::Ghost || pi.type == ParticleType::DummyWall)
-			continue;
-
-		for (auto& neighbor : pi.neighbors) {
-			Particle& pj = particles[neighbor.id];
-			if (pj.type == ParticleType::Ghost || pj.type == ParticleType::DummyWall)
-				continue;
-			if (pj.id > pi.id)
-				continue;
-
-			if (neighbor.distance < re) {
-				pi.minimumPressure = std::min(pi.minimumPressure, pj.pressure);
-				pj.minimumPressure = std::min(pj.minimumPressure, pi.pressure);
-			}
 		}
 	}
 }

--- a/src/mps.cpp
+++ b/src/mps.cpp
@@ -34,7 +34,11 @@ void MPS::stepForward() {
 	setNeighbors(settings.reMax);
 	calNumberDensity(settings.re_forNumberDensity);
 	setBoundaryCondition();
-	pressureCalculator->calc(particles);
+	auto pressures = pressureCalculator->calc(particles);
+	for (auto& particle: particles) {
+		particle.pressure = pressures[particle.id];
+	}
+
 	setMinimumPressure(settings.re_forGradient);
 	calPressureGradient(settings.re_forGradient);
 	moveParticleUsingPressureGradient();

--- a/src/mps.hpp
+++ b/src/mps.hpp
@@ -9,6 +9,7 @@
 #include "settings.hpp"
 #include <Eigen/Dense>
 #include <Eigen/Sparse>
+#include <memory>
 #include <vector>
 
 /**
@@ -21,7 +22,7 @@ class MPS {
 public:
 	Settings settings;               ///< Settings for the simulation
 	RefValues refValuesForLaplacian; ///< Reference values for the simulation (\f$n^0\f$, \f$\lambda^0\f$)
-	RefValues refValuesForGradient;             ///< Reference values for the simulation (\f$n^0\f$, \f$\lambda^0\f$)
+	RefValues refValuesForGradient;  ///< Reference values for the simulation (\f$n^0\f$, \f$\lambda^0\f$)
 	std::vector<Particle> particles; ///< Particles in the simulation
 	Bucket bucket;                   ///< Bucket for neighbor search
 	Domain domain;                   ///< Domain of the simulation
@@ -32,7 +33,7 @@ public:
 
 	MPS() = default;
 
-	MPS(const Input& input, std::unique_ptr<IPressureCalculator> pressureCalculator);
+	MPS(const Input& input, std::unique_ptr<IPressureCalculator>&& pressureCalculator);
 
 	void stepForward();
 

--- a/src/mps.hpp
+++ b/src/mps.hpp
@@ -81,6 +81,12 @@ private:
 	void setBoundaryCondition();
 
 	/**
+	 * @brief set minimum pressure for pressure gradient calculation
+	 * @param re effective radius \f$r_e\f$
+	 */
+	void MPS::setMinimumPressure(const double& re);
+
+	/**
 	 * @brief calculate pressure gradient term
 	 * @param re
 	 * @details

--- a/src/mps.hpp
+++ b/src/mps.hpp
@@ -20,7 +20,8 @@
 class MPS {
 public:
 	Settings settings;               ///< Settings for the simulation
-	RefValues refValues;             ///< Reference values for the simulation (\f$n^0\f$, \f$\lambda^0\f$)
+	RefValues refValuesForLaplacian; ///< Reference values for the simulation (\f$n^0\f$, \f$\lambda^0\f$)
+	RefValues refValuesForGradient;             ///< Reference values for the simulation (\f$n^0\f$, \f$\lambda^0\f$)
 	std::vector<Particle> particles; ///< Particles in the simulation
 	Bucket bucket;                   ///< Bucket for neighbor search
 	Domain domain;                   ///< Domain of the simulation
@@ -32,8 +33,6 @@ public:
 	MPS() = default;
 
 	MPS(const Input& input, std::unique_ptr<IPressureCalculator> pressureCalculator);
-
-	void init();
 
 	void stepForward();
 
@@ -74,11 +73,6 @@ private:
 	 * @param re effective radius \f$r_e\f$
 	 */
 	void calNumberDensity(const double& re);
-
-	/**
-	 *@brief set boundary condition of pressure Poisson equation
-	 */
-	void setBoundaryCondition();
 
 	/**
 	 * @brief set minimum pressure for pressure gradient calculation

--- a/src/mps.hpp
+++ b/src/mps.hpp
@@ -28,13 +28,13 @@ public:
 	Bucket bucket;                   ///< Bucket for neighbor search
 	Domain domain;                   ///< Domain of the simulation
 
-	std::unique_ptr<IPressureCalculator> pressureCalculator; ///< Interface for pressure calculation
+	std::unique_ptr<PressureCalculator::Interface> pressureCalculator; ///< Interface for pressure calculation
 
 	double courant; ///< Maximum courant number among all particles
 
 	MPS() = default;
 
-	MPS(const Input& input, std::unique_ptr<IPressureCalculator>&& pressureCalculator);
+	MPS(const Input& input, std::unique_ptr<PressureCalculator::Interface>&& pressureCalculator);
 
 	void stepForward();
 

--- a/src/mps.hpp
+++ b/src/mps.hpp
@@ -21,6 +21,7 @@
 class MPS {
 public:
 	Settings settings;               ///< Settings for the simulation
+	RefValues refValuesForNumberDensity; ///< Reference values for the simulation (\f$n^0\f$, \f$\lambda^0\f$)
 	RefValues refValuesForLaplacian; ///< Reference values for the simulation (\f$n^0\f$, \f$\lambda^0\f$)
 	RefValues refValuesForGradient;  ///< Reference values for the simulation (\f$n^0\f$, \f$\lambda^0\f$)
 	std::vector<Particle> particles; ///< Particles in the simulation
@@ -74,6 +75,11 @@ private:
 	 * @param re effective radius \f$r_e\f$
 	 */
 	void calNumberDensity(const double& re);
+
+	/**
+	 *@brief set boundary condition of pressure Poisson equation
+	 */
+	void setBoundaryCondition();
 
 	/**
 	 * @brief set minimum pressure for pressure gradient calculation

--- a/src/mps.hpp
+++ b/src/mps.hpp
@@ -78,7 +78,7 @@ private:
 	 * @brief set minimum pressure for pressure gradient calculation
 	 * @param re effective radius \f$r_e\f$
 	 */
-	void MPS::setMinimumPressure(const double& re);
+	void setMinimumPressure(const double& re);
 
 	/**
 	 * @brief calculate pressure gradient term

--- a/src/pressure_calculator/implicit.cpp
+++ b/src/pressure_calculator/implicit.cpp
@@ -10,7 +10,6 @@ void ImplicitPressureCalculator::calc(std::vector<Particle>& particles) {
     setMatrix();
     solveSimultaneousEquations();
     removeNegativePressure();
-    setMinimumPressure();
 }
 
 void ImplicitPressureCalculator::setSourceTerm() {
@@ -122,33 +121,6 @@ void ImplicitPressureCalculator::removeNegativePressure() {
 	for (auto& p : particles) {
 		if (p.pressure < 0.0) {
 			p.pressure = 0.0;
-		}
-	}
-}
-
-void ImplicitPressureCalculator::setMinimumPressure() {
-    auto re = re_forGradient;
-
-#pragma omp parallel for
-	for (auto& p : particles) {
-		p.minimumPressure = p.pressure;
-	}
-
-	for (auto& pi : particles) {
-		if (pi.type == ParticleType::Ghost || pi.type == ParticleType::DummyWall)
-			continue;
-
-		for (auto& neighbor : pi.neighbors) {
-			Particle& pj = particles[neighbor.id];
-			if (pj.type == ParticleType::Ghost || pj.type == ParticleType::DummyWall)
-				continue;
-			if (pj.id > pi.id)
-				continue;
-
-			if (neighbor.distance < re) {
-				pi.minimumPressure = std::min(pi.minimumPressure, pj.pressure);
-				pj.minimumPressure = std::min(pj.minimumPressure, pi.pressure);
-			}
 		}
 	}
 }

--- a/src/pressure_calculator/implicit.cpp
+++ b/src/pressure_calculator/implicit.cpp
@@ -1,0 +1,154 @@
+#include "implicit.hpp"
+#include <queue>
+
+using namespace std::cerr;
+using namespace std::endl;
+
+void ImplicitPressureCalculator::calc(std::vector<Particle>& particles) {
+    this->particles = particles;
+    setSourceTerm();
+    setMatrix();
+    solveSimultaneousEquations();
+    removeNegativePressure();
+    setMinimumPressure();
+}
+
+void ImplicitPressureCalculator::setSourceTerm() {
+	double n0    = n0_forNumberDensity;
+	double gamma = relaxationCoefficient;
+
+#pragma omp parallel for
+	for (auto& pi : particles) {
+		pi.sourceTerm = 0.0;
+		if (pi.boundaryCondition == FluidState::Inner) {
+			pi.sourceTerm = gamma * (1.0 / (dt * dt)) * ((pi.numberDensity - n0) / n0);
+		}
+	}
+}
+
+void ImplicitPressureCalculator::setMatrix() {
+	std::vector<Eigen::Triplet<double>> triplets;
+	auto n0 = n0_forLaplacian;
+	auto a  = 2.0 * dimension / (n0 * lambda);
+    auto re = re_forLaplacian;
+	coefficientMatrix.resize(particles.size(), particles.size());
+
+	for (auto& pi : particles) {
+		if (pi.boundaryCondition != FluidState::Inner)
+			continue;
+
+		double coefficient_ii = 0.0;
+		for (auto& neighbor : pi.neighbors) {
+			Particle& pj = particles[neighbor.id];
+			if (pj.boundaryCondition == FluidState::Ignored)
+				continue;
+
+			if (neighbor.distance < re) {
+				double coefficient_ij = a * weight(neighbor.distance, re) / fluidDensity;
+				triplets.emplace_back(pi.id, pj.id, -1.0 * coefficient_ij);
+				coefficient_ii += coefficient_ij;
+			}
+		}
+		coefficient_ii += (compressibility) / (dt * dt);
+		triplets.emplace_back(pi.id, pi.id, coefficient_ii);
+	}
+	coefficientMatrix.setFromTriplets(triplets.begin(), triplets.end());
+
+	// exceptionalProcessingForBoundaryCondition();
+}
+
+
+void ImplicitPressureCalculator::exceptionalProcessingForBoundaryCondition() {
+	std::vector<bool> checked(particles.size(), false);
+	std::vector<bool> connected(particles.size(), false);
+
+	for (auto& pi : particles) {
+		if (pi.boundaryCondition == FluidState::FreeSurface)
+			connected[pi.id] = true;
+		if (connected[pi.id])
+			continue;
+		// BFS for connected components
+		std::queue<size_t> queue;
+		queue.push(pi.id);
+		checked[pi.id] = true;
+		while (!queue.empty()) {
+			// pop front element
+			auto v = queue.front();
+			queue.pop();
+			// search for adjacent nodes
+			for (Eigen::SparseMatrix<double, Eigen::RowMajor>::InnerIterator it(coefficientMatrix, v); it; ++it) {
+				auto nv = it.col();
+				if (!checked[nv]) {
+					if (connected[nv]) { // connected to boundary
+						connected[v] = true;
+						checked[v]   = true;
+						break;
+
+					} else {
+						queue.push(nv);
+						checked[nv] = true;
+					}
+				}
+			}
+		}
+	}
+}
+
+void ImplicitPressureCalculator::solveSimultaneousEquations() {
+	sourceTerm.resize(particles.size());
+	pressure.resize(particles.size());
+
+#pragma omp parallel for
+	for (auto& pi : particles) {
+		sourceTerm[pi.id] = pi.sourceTerm;
+	}
+
+	Eigen::BiCGSTAB<Eigen::SparseMatrix<double, Eigen::RowMajor>> solver;
+	solver.compute(coefficientMatrix);
+	pressure = solver.solve(sourceTerm);
+	if (solver.info() != Eigen::Success) {
+		cerr << "Pressure calculation failed." << endl;
+		std::exit(-1);
+	}
+
+#pragma omp parallel for
+	for (auto& pi : particles) {
+		pi.pressure = pressure[pi.id];
+	}
+}
+
+void ImplicitPressureCalculator::removeNegativePressure() {
+#pragma omp parallel for
+	for (auto& p : particles) {
+		if (p.pressure < 0.0) {
+			p.pressure = 0.0;
+		}
+	}
+}
+
+void ImplicitPressureCalculator::setMinimumPressure() {
+    auto re = re_forGradient;
+
+#pragma omp parallel for
+	for (auto& p : particles) {
+		p.minimumPressure = p.pressure;
+	}
+
+	for (auto& pi : particles) {
+		if (pi.type == ParticleType::Ghost || pi.type == ParticleType::DummyWall)
+			continue;
+
+		for (auto& neighbor : pi.neighbors) {
+			Particle& pj = particles[neighbor.id];
+			if (pj.type == ParticleType::Ghost || pj.type == ParticleType::DummyWall)
+				continue;
+			if (pj.id > pi.id)
+				continue;
+
+			if (neighbor.distance < re) {
+				pi.minimumPressure = std::min(pi.minimumPressure, pj.pressure);
+				pj.minimumPressure = std::min(pj.minimumPressure, pi.pressure);
+			}
+		}
+	}
+}

--- a/src/pressure_calculator/implicit.cpp
+++ b/src/pressure_calculator/implicit.cpp
@@ -1,15 +1,33 @@
 #include "implicit.hpp"
+#include "../weight.hpp"
+#include <iostream>
 #include <queue>
+#include "../refvalues.hpp"
 
-using namespace std::cerr;
-using namespace std::endl;
+using std::cerr;
+using std::endl;
+
+ImplicitPressureCalculator::ImplicitPressureCalculator(int dimension,
+                                                       double particleDistance,
+                                                       double re_forGradient,
+                                                       double re_forLaplacian,
+                                                       double dt,
+                                                       double fluidDensity,
+                                                       double compressibility,
+                                                       double relaxationCoefficient)
+    : dimension(dimension), re_forGradient(re_forGradient), re_forLaplacian(re_forLaplacian), dt(dt),
+      fluidDensity(fluidDensity), compressibility(compressibility), relaxationCoefficient(relaxationCoefficient) {
+
+		RefValues refValues;
+		refValues.calc(dimension, particleDistance, re_forLaplacian, re_forGradient, re_forLaplacian);
+}
 
 void ImplicitPressureCalculator::calc(std::vector<Particle>& particles) {
-    this->particles = particles;
-    setSourceTerm();
-    setMatrix();
-    solveSimultaneousEquations();
-    removeNegativePressure();
+	this->particles = particles;
+	setSourceTerm();
+	setMatrix();
+	solveSimultaneousEquations();
+	removeNegativePressure();
 }
 
 void ImplicitPressureCalculator::setSourceTerm() {
@@ -29,7 +47,7 @@ void ImplicitPressureCalculator::setMatrix() {
 	std::vector<Eigen::Triplet<double>> triplets;
 	auto n0 = n0_forLaplacian;
 	auto a  = 2.0 * dimension / (n0 * lambda);
-    auto re = re_forLaplacian;
+	auto re = re_forLaplacian;
 	coefficientMatrix.resize(particles.size(), particles.size());
 
 	for (auto& pi : particles) {
@@ -55,7 +73,6 @@ void ImplicitPressureCalculator::setMatrix() {
 
 	// exceptionalProcessingForBoundaryCondition();
 }
-
 
 void ImplicitPressureCalculator::exceptionalProcessingForBoundaryCondition() {
 	std::vector<bool> checked(particles.size(), false);

--- a/src/pressure_calculator/implicit.cpp
+++ b/src/pressure_calculator/implicit.cpp
@@ -28,6 +28,7 @@ void ImplicitPressureCalculator::calc(std::vector<Particle>& particles) {
 	setMatrix();
 	solveSimultaneousEquations();
 	removeNegativePressure();
+	particles = this->particles;
 }
 
 ImplicitPressureCalculator::~ImplicitPressureCalculator() {

--- a/src/pressure_calculator/implicit.cpp
+++ b/src/pressure_calculator/implicit.cpp
@@ -39,10 +39,9 @@ void ImplicitPressureCalculator::setSourceTerm() {
 
 #pragma omp parallel for
 	for (auto& pi : particles) {
+		pi.sourceTerm = 0.0;
 		if (pi.boundaryCondition == FluidState::Inner) {
-			sourceTerm[pi.id] = gamma * (1.0 / (dt * dt)) * ((pi.numberDensity - n0) / n0);
-		} else {
-			sourceTerm[pi.id] = 0.0;
+			pi.sourceTerm = gamma * (1.0 / (dt * dt)) * ((pi.numberDensity - n0) / n0);
 		}
 	}
 }

--- a/src/pressure_calculator/implicit.cpp
+++ b/src/pressure_calculator/implicit.cpp
@@ -22,9 +22,6 @@ ImplicitPressureCalculator::ImplicitPressureCalculator(int dimension,
 	refValuesForLaplacian     = RefValues(dimension, particleDistance, reForLaplacian);
 }
 
-ImplicitPressureCalculator::~ImplicitPressureCalculator() {
-}
-
 void ImplicitPressureCalculator::calc(std::vector<Particle>& particles) {
 	this->particles = particles;
 	setSourceTerm();
@@ -33,15 +30,19 @@ void ImplicitPressureCalculator::calc(std::vector<Particle>& particles) {
 	removeNegativePressure();
 }
 
+ImplicitPressureCalculator::~ImplicitPressureCalculator() {
+}
+
 void ImplicitPressureCalculator::setSourceTerm() {
 	double n0    = refValuesForNumberDensity.n0;
 	double gamma = relaxationCoefficient;
 
 #pragma omp parallel for
 	for (auto& pi : particles) {
-		pi.sourceTerm = 0.0;
 		if (pi.boundaryCondition == FluidState::Inner) {
-			pi.sourceTerm = gamma * (1.0 / (dt * dt)) * ((pi.numberDensity - n0) / n0);
+			sourceTerm[pi.id] = gamma * (1.0 / (dt * dt)) * ((pi.numberDensity - n0) / n0);
+		} else {
+			sourceTerm[pi.id] = 0.0;
 		}
 	}
 }

--- a/src/pressure_calculator/implicit.hpp
+++ b/src/pressure_calculator/implicit.hpp
@@ -13,6 +13,7 @@ public:
 	 * @param particles particles
 	 */
 	void calc(std::vector<Particle>& particles) override;
+	~ImplicitPressureCalculator() override;
 
 	ImplicitPressureCalculator(int dimension,
 	                           double particleDistance,
@@ -22,7 +23,6 @@ public:
 	                           double fluidDensity,
 	                           double compressibility,
 	                           double relaxationCoefficient);
-	~ImplicitPressureCalculator() override;
 
 private:
 	int dimension;

--- a/src/pressure_calculator/implicit.hpp
+++ b/src/pressure_calculator/implicit.hpp
@@ -93,10 +93,4 @@ private:
 	 * @brief remove negative pressure for stability
 	 */
 	void removeNegativePressure();
-
-	/**
-	 * @brief set minimum pressure for pressure gradient calculation
-	 * @param re effective radius \f$r_e\f$
-	 */
-	void setMinimumPressure(const double& re);
 };

--- a/src/pressure_calculator/implicit.hpp
+++ b/src/pressure_calculator/implicit.hpp
@@ -12,7 +12,7 @@ public:
 	 * @brief calculate pressure
 	 * @param particles particles
 	 */
-	void calc(std::vector<Particle>& particles) override;
+	std::vector<double> calc(const std::vector<Particle>& particles) override;
 	~ImplicitPressureCalculator() override;
 
 	ImplicitPressureCalculator(int dimension,

--- a/src/pressure_calculator/implicit.hpp
+++ b/src/pressure_calculator/implicit.hpp
@@ -1,11 +1,12 @@
 #pragma once
 
 #include "../particle.hpp"
+#include "../refvalues.hpp"
 #include "interface.hpp"
 #include <Eigen/Sparse>
 #include <vector>
 
-class ImplicitPressureCalculator : IPressureCalculator {
+class ImplicitPressureCalculator : public IPressureCalculator {
 public:
 	/**
 	 * @brief calculate pressure
@@ -21,15 +22,14 @@ public:
 	                           double fluidDensity,
 	                           double compressibility,
 	                           double relaxationCoefficient);
-	~ImplicitPressureCalculator() override = default;
+	~ImplicitPressureCalculator() override;
 
 private:
 	int dimension;
-	double n0_forNumberDensity;
-	double n0_forLaplacian;
-	double lambda;
-	double re_forGradient;
-	double re_forLaplacian;
+	RefValues refValuesForNumberDensity;
+	RefValues refValuesForLaplacian;
+	double reForNumberDensity;
+	double reForLaplacian;
 	double dt;
 	double fluidDensity;
 	double compressibility;

--- a/src/pressure_calculator/implicit.hpp
+++ b/src/pressure_calculator/implicit.hpp
@@ -1,0 +1,102 @@
+#pragma once
+
+#include "interface.hpp"
+#include "particle.hpp"
+#include <vector>
+#include <Eigen/Sparse>
+
+class ImplicitPressureCalculator : IPressureCalculator {
+public:
+    /**
+     * @brief calculate pressure
+     * @param particles particles
+     */
+    void calc(std::vector<Particle>& particles) override;
+
+	ImplicitPressureCalculator(
+	    int dimension,
+		double n0_forNumberDensity,
+		double n0_forLaplacian,
+		double lambda,
+		double re_forGradient,
+		double re_forLaplacian,
+		double dt,
+		double fluidDensity,
+		double compressibility,
+		double relaxationCoefficient)
+		: dimension(dimension),
+		  n0_forNumberDensity(n0_forNumberDensity),
+		  n0_forLaplacian(n0_forLaplacian),
+		  lambda(lambda),
+		  re_forGradient(re_forGradient),
+		  re_forLaplacian(re_forLaplacian),
+		  dt(dt),
+		  fluidDensity(fluidDensity),
+		  compressibility(compressibility),
+		  relaxationCoefficient(relaxationCoefficient) {}
+private:
+    int dimension;
+	double n0_forNumberDensity;
+	double n0_forLaplacian;
+	double lambda;
+	double re_forGradient;
+	double re_forLaplacian;
+	double dt;
+	double fluidDensity;
+	double compressibility;
+	double relaxationCoefficient;
+
+	std::vector<Particle> particles;
+
+	Eigen::SparseMatrix<double, Eigen::RowMajor>
+	    coefficientMatrix;      ///< Coefficient matrix for pressure Poisson equation
+	Eigen::VectorXd sourceTerm; ///< Source term for pressure Poisson equation
+	Eigen::VectorXd pressure;   ///< Solution of pressure Poisson equation
+
+	/**
+	 * @brief set source term of pressure Poisson equation
+	 * @details
+	 * The source term of the pressure Poisson equation is calculated as follows:
+	 * \f[
+	 * b_i = \frac{\gamma}{\Delta t^2}\frac{n_i-n^0}{n^0}
+	 * \f]
+	 */
+	void setSourceTerm();
+
+	/**
+	 * @brief set coefficient matrix of pressure Poisson equation
+	 * @param re  effective radius \f$r_e\f$
+	 * @details
+	 * Applying Laplacian model to pressure Poisson equation, the coefficient matrix is calculated as follows:
+	 * \f[
+	 *	-\frac{1}{\rho^0}\langle\nabla^2 P\rangle_i^{k+1} = b_i.
+	 * \f]
+	 */
+	void setMatrix(const double& re);
+
+	/**
+	 * @brief If there is no Dirichlet boundary condition on the fluid,
+	       increase the diagonal terms of the matrix for an exception. This
+	       allows us to solve the matrix without Dirichlet boundary conditions.
+	 *
+	 */
+	void exceptionalProcessingForBoundaryCondition();
+
+	/**
+	 * @brief Solve the pressure Poisson equation
+	 * @details
+	 * The pressure Poisson equation is solved using the BiCGSTAB method.
+	 */
+	void solveSimultaneousEquations();
+
+	/**
+	 * @brief remove negative pressure for stability
+	 */
+	void removeNegativePressure();
+
+	/**
+	 * @brief set minimum pressure for pressure gradient calculation
+	 * @param re effective radius \f$r_e\f$
+	 */
+	void setMinimumPressure(const double& re);
+};

--- a/src/pressure_calculator/implicit.hpp
+++ b/src/pressure_calculator/implicit.hpp
@@ -8,7 +8,7 @@
 
 namespace PressureCalculator {
 
-class Implicit : public IPressureCalculator {
+class Implicit : public Interface {
 public:
 	/**
 	 * @brief calculate pressure

--- a/src/pressure_calculator/implicit.hpp
+++ b/src/pressure_calculator/implicit.hpp
@@ -6,23 +6,25 @@
 #include <Eigen/Sparse>
 #include <vector>
 
-class ImplicitPressureCalculator : public IPressureCalculator {
+namespace PressureCalculator {
+
+class Implicit : public IPressureCalculator {
 public:
 	/**
 	 * @brief calculate pressure
 	 * @param particles particles
 	 */
 	std::vector<double> calc(const std::vector<Particle>& particles) override;
-	~ImplicitPressureCalculator() override;
+	~Implicit() override;
 
-	ImplicitPressureCalculator(int dimension,
-	                           double particleDistance,
-	                           double re_forGradient,
-	                           double re_forLaplacian,
-	                           double dt,
-	                           double fluidDensity,
-	                           double compressibility,
-	                           double relaxationCoefficient);
+	Implicit(int dimension,
+	         double particleDistance,
+	         double re_forGradient,
+	         double re_forLaplacian,
+	         double dt,
+	         double fluidDensity,
+	         double compressibility,
+	         double relaxationCoefficient);
 
 private:
 	int dimension;
@@ -83,3 +85,5 @@ private:
 	 */
 	void removeNegativePressure();
 };
+
+} // namespace PressureCalculator

--- a/src/pressure_calculator/implicit.hpp
+++ b/src/pressure_calculator/implicit.hpp
@@ -1,41 +1,30 @@
 #pragma once
 
+#include "../particle.hpp"
 #include "interface.hpp"
-#include "particle.hpp"
-#include <vector>
 #include <Eigen/Sparse>
+#include <vector>
 
 class ImplicitPressureCalculator : IPressureCalculator {
 public:
-    /**
-     * @brief calculate pressure
-     * @param particles particles
-     */
-    void calc(std::vector<Particle>& particles) override;
+	/**
+	 * @brief calculate pressure
+	 * @param particles particles
+	 */
+	void calc(std::vector<Particle>& particles) override;
 
-	ImplicitPressureCalculator(
-	    int dimension,
-		double n0_forNumberDensity,
-		double n0_forLaplacian,
-		double lambda,
-		double re_forGradient,
-		double re_forLaplacian,
-		double dt,
-		double fluidDensity,
-		double compressibility,
-		double relaxationCoefficient)
-		: dimension(dimension),
-		  n0_forNumberDensity(n0_forNumberDensity),
-		  n0_forLaplacian(n0_forLaplacian),
-		  lambda(lambda),
-		  re_forGradient(re_forGradient),
-		  re_forLaplacian(re_forLaplacian),
-		  dt(dt),
-		  fluidDensity(fluidDensity),
-		  compressibility(compressibility),
-		  relaxationCoefficient(relaxationCoefficient) {}
+	ImplicitPressureCalculator(int dimension,
+	                           double particleDistance,
+	                           double re_forGradient,
+	                           double re_forLaplacian,
+	                           double dt,
+	                           double fluidDensity,
+	                           double compressibility,
+	                           double relaxationCoefficient);
+	~ImplicitPressureCalculator() override = default;
+
 private:
-    int dimension;
+	int dimension;
 	double n0_forNumberDensity;
 	double n0_forLaplacian;
 	double lambda;
@@ -72,7 +61,7 @@ private:
 	 *	-\frac{1}{\rho^0}\langle\nabla^2 P\rangle_i^{k+1} = b_i.
 	 * \f]
 	 */
-	void setMatrix(const double& re);
+	void setMatrix();
 
 	/**
 	 * @brief If there is no Dirichlet boundary condition on the fluid,

--- a/src/pressure_calculator/interface.hpp
+++ b/src/pressure_calculator/interface.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "../particle.hpp"
+#include <vector>
+
+/**
+ * @brief Pressure calculator interface
+ *
+ * @details Interface for pressure calculator. This interface is used to
+ * calculate pressure in the MPS method.
+ */
+class IPressureCalculator {
+    /**
+     * @brief calculate pressure
+     * @param particles particles
+     */
+	virtual void calc(std::vector<Particle>& particles) = 0;
+
+    /**
+     * @brief destructor
+     */
+    ~IPressureCalculator() = default;
+};

--- a/src/pressure_calculator/interface.hpp
+++ b/src/pressure_calculator/interface.hpp
@@ -14,8 +14,10 @@ public:
 	/**
 	 * @brief calculate pressure
 	 * @param particles particles
+	 *
+	 * @return pressures of particles
 	 */
-	virtual void calc(std::vector<Particle>& particles) = 0;
+	virtual std::vector<double> calc(const std::vector<Particle>& particles) = 0;
 
 	/**
 	 * @brief destructor

--- a/src/pressure_calculator/interface.hpp
+++ b/src/pressure_calculator/interface.hpp
@@ -20,5 +20,5 @@ public:
 	/**
 	 * @brief destructor
 	 */
-	virtual ~IPressureCalculator() = 0;
+	virtual ~IPressureCalculator() {};
 };

--- a/src/pressure_calculator/interface.hpp
+++ b/src/pressure_calculator/interface.hpp
@@ -10,14 +10,15 @@
  * calculate pressure in the MPS method.
  */
 class IPressureCalculator {
-    /**
-     * @brief calculate pressure
-     * @param particles particles
-     */
+public:
+	/**
+	 * @brief calculate pressure
+	 * @param particles particles
+	 */
 	virtual void calc(std::vector<Particle>& particles) = 0;
 
-    /**
-     * @brief destructor
-     */
-    ~IPressureCalculator() = default;
+	/**
+	 * @brief destructor
+	 */
+	virtual ~IPressureCalculator() = 0;
 };

--- a/src/pressure_calculator/interface.hpp
+++ b/src/pressure_calculator/interface.hpp
@@ -3,13 +3,15 @@
 #include "../particle.hpp"
 #include <vector>
 
+namespace PressureCalculator {
+
 /**
  * @brief Pressure calculator interface
  *
  * @details Interface for pressure calculator. This interface is used to
  * calculate pressure in the MPS method.
  */
-class IPressureCalculator {
+class Interface {
 public:
 	/**
 	 * @brief calculate pressure
@@ -22,5 +24,7 @@ public:
 	/**
 	 * @brief destructor
 	 */
-	virtual ~IPressureCalculator() {};
+	virtual ~Interface() {};
 };
+
+}

--- a/src/refvalues.cpp
+++ b/src/refvalues.cpp
@@ -1,10 +1,12 @@
 #include "refvalues.hpp"
 #include "weight.hpp"
+#include <cassert>
 #include <cmath>
 #include <utility>
 
 RefValues::RefValues(int dim, double particleDistance, double re) {
-
+	assert(dim == 2 || dim == 3);
+	assert(particleDistance < re);
 	int iZ_start = -4;
 	int iZ_end   = 5;
 	if (dim == 2) {

--- a/src/refvalues.cpp
+++ b/src/refvalues.cpp
@@ -1,23 +1,19 @@
 #include "refvalues.hpp"
 #include "weight.hpp"
 #include <cmath>
+#include <utility>
 
-void RefValues::calc(
-    int dim, double particleDistance, double re_forNumberDensity, double re_forGradient, double re_forLaplacian) {
+RefValues::RefValues(int dim, double particleDistance, double re) {
 
-	int iZ_start, iZ_end;
+	int iZ_start = -4;
+	int iZ_end   = 5;
 	if (dim == 2) {
 		iZ_start = 0;
 		iZ_end   = 1;
-	} else {
-		iZ_start = -4;
-		iZ_end   = 5;
 	}
 
-	this->n0_forNumberDensity = 0.0;
-	this->n0_forGradient      = 0.0;
-	this->n0_forLaplacian     = 0.0;
-	this->lambda              = 0.0;
+	this->n0     = 0.0;
+	this->lambda = 0.0;
 	for (int iX = -4; iX < 5; iX++) {
 		for (int iY = -4; iY < 5; iY++) {
 			for (int iZ = iZ_start; iZ < iZ_end; iZ++) {
@@ -29,12 +25,10 @@ void RefValues::calc(
 				double zj   = particleDistance * (double) (iZ);
 				double dis2 = xj * xj + yj * yj + zj * zj;
 				double dis  = sqrt(dis2);
-				this->n0_forNumberDensity += weight(dis, re_forNumberDensity);
-				this->n0_forGradient += weight(dis, re_forGradient);
-				this->n0_forLaplacian += weight(dis, re_forLaplacian);
-				this->lambda += dis2 * weight(dis, re_forLaplacian);
+				n0 += weight(dis, re);
+				lambda += dis2 * weight(dis, re);
 			}
 		}
 	}
-	this->lambda /= this->n0_forLaplacian;
+	this->lambda /= this->n0;
 }

--- a/src/refvalues.hpp
+++ b/src/refvalues.hpp
@@ -6,22 +6,17 @@
  *  @brief Struct for reference values of MPS method
  */
 class RefValues {
-private:
 public:
-	double n0_forNumberDensity; ///< reference value of number density for source term of pressure Poisson equation
-	double n0_forGradient;      ///< reference value of number density for gradient
-	double n0_forLaplacian;     ///< reference value of number density for laplacian
-	double lambda;              ///< coefficient for laplacian
+	double n0     = 0; ///< reference value of number density for source term of pressure Poisson equation
+	double lambda = 0; ///< coefficient for laplacian
 
+	RefValues() = default;
 	/**
 	 * @brief calculate reference values for MPS method
 	 *
 	 * @param dim dimension of the simulation
 	 * @param particleDistance initial particle distance
-	 * @param re_forNumberDensity effective radius when calculating number density
-	 * @param re_forGradient effective radius when calculating gradient
-	 * @param re_forLaplacian effective radius when calculating laplacian
+	 * @param re effective radius
 	 */
-	void
-	calc(int dim, double particleDistance, double re_forNumberDensity, double re_forGradient, double re_forLaplacian);
+	RefValues(int dim, double particleDistance, double re);
 };

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -14,7 +14,7 @@ Simulation::Simulation(fs::path& settingPath) {
 	Input input = loader.load(settingPath);
 	saver       = Saver(input.settings.outputDirectory);
 
-	std::unique_ptr<IPressureCalculator> pressureCalculator(
+	std::unique_ptr<PressureCalculator::Interface> pressureCalculator(
 		new PressureCalculator::Implicit(
 			input.settings.dim,
 			input.settings.particleDistance,

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -1,7 +1,9 @@
 #include "simulation.hpp"
 #include "input.hpp"
+#include "pressure_calculator/implicit.hpp"
 #include <cstdio>
 #include <iostream>
+#include <memory>
 
 using std::cout;
 using std::endl;
@@ -12,16 +14,8 @@ Simulation::Simulation(fs::path& settingPath) {
 	Input input = loader.load(settingPath);
 	saver       = Saver(input.settings.outputDirectory);
 
-	ImplicitPressureCalculator pressureCalculator(
-		input.settings.dim,
-		input.settings.re_forNumberDensity,
-		input.settings.re_forLaplacian,
-		input.settings.lambda, // settings には lambda がない、、ここでは注入できないか、、
-		input.settings.re_forGradient,
-		input.settings.re_forLaplacian,
-		input.settings.relaxationCoefficientForPressure, input.settings.dt
-	);
-	mps          = MPS(input, pressureCalculator);
+	std::unique_ptr<IPressureCalculator> pressureCalculator ;
+	mps          = MPS(input, std::move(pressureCalculator));
 	startTime    = input.startTime;
 	time         = startTime;
 	endTime      = input.settings.endTime;

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -12,7 +12,16 @@ Simulation::Simulation(fs::path& settingPath) {
 	Input input = loader.load(settingPath);
 	saver       = Saver(input.settings.outputDirectory);
 
-	mps          = MPS(input);
+	ImplicitPressureCalculator pressureCalculator(
+		input.settings.dim,
+		input.settings.re_forNumberDensity,
+		input.settings.re_forLaplacian,
+		input.settings.lambda, // settings には lambda がない、、ここでは注入できないか、、
+		input.settings.re_forGradient,
+		input.settings.re_forLaplacian,
+		input.settings.relaxationCoefficientForPressure, input.settings.dt
+	);
+	mps          = MPS(input, pressureCalculator);
 	startTime    = input.startTime;
 	time         = startTime;
 	endTime      = input.settings.endTime;

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -14,7 +14,14 @@ Simulation::Simulation(fs::path& settingPath) {
 	Input input = loader.load(settingPath);
 	saver       = Saver(input.settings.outputDirectory);
 
-	std::unique_ptr<IPressureCalculator> pressureCalculator ;
+	std::unique_ptr<IPressureCalculator> pressureCalculator(new ImplicitPressureCalculator(input.settings.dim,
+		input.settings.particleDistance,
+		input.settings.re_forNumberDensity,
+		input.settings.re_forLaplacian,
+		input.settings.dt,
+		input.settings.fluidDensity,
+		input.settings.compressibility,
+		input.settings.relaxationCoefficientForPressure));
 	mps          = MPS(input, std::move(pressureCalculator));
 	startTime    = input.startTime;
 	time         = startTime;
@@ -25,7 +32,6 @@ Simulation::Simulation(fs::path& settingPath) {
 
 void Simulation::run() {
 	startSimulation();
-	mps.init();
 	saver.save(mps, time);
 
 	while (time < endTime) {

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -15,7 +15,7 @@ Simulation::Simulation(fs::path& settingPath) {
 	saver       = Saver(input.settings.outputDirectory);
 
 	std::unique_ptr<IPressureCalculator> pressureCalculator(
-		new ImplicitPressureCalculator(
+		new PressureCalculator::Implicit(
 			input.settings.dim,
 			input.settings.particleDistance,
 			input.settings.re_forNumberDensity,

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -14,14 +14,19 @@ Simulation::Simulation(fs::path& settingPath) {
 	Input input = loader.load(settingPath);
 	saver       = Saver(input.settings.outputDirectory);
 
-	std::unique_ptr<IPressureCalculator> pressureCalculator(new ImplicitPressureCalculator(input.settings.dim,
-		input.settings.particleDistance,
-		input.settings.re_forNumberDensity,
-		input.settings.re_forLaplacian,
-		input.settings.dt,
-		input.settings.fluidDensity,
-		input.settings.compressibility,
-		input.settings.relaxationCoefficientForPressure));
+	std::unique_ptr<IPressureCalculator> pressureCalculator(
+		new ImplicitPressureCalculator(
+			input.settings.dim,
+			input.settings.particleDistance,
+			input.settings.re_forNumberDensity,
+			input.settings.re_forLaplacian,
+			input.settings.dt,
+			input.settings.fluidDensity,
+			input.settings.compressibility,
+			input.settings.relaxationCoefficientForPressure
+		)
+	);
+
 	mps          = MPS(input, std::move(pressureCalculator));
 	startTime    = input.startTime;
 	time         = startTime;

--- a/test/refvalues_test.cpp
+++ b/test/refvalues_test.cpp
@@ -3,48 +3,25 @@
 #include <cmath>
 #include <gtest/gtest.h>
 
-TEST(RefValuesTest, NumberDensityForGradientTest2d) {
-	double l0                  = 0.1;
-	double re_forNumberDensity = 2.5 * l0;
-	double re_forGradient      = 1.5 * l0;
-	double re_forLaplacian     = 3.1 * l0;
-	RefValues ref;
-	ref.calc(2, l0, re_forNumberDensity, re_forGradient, re_forLaplacian);
+TEST(RefValuesTest, test2d) {
+	double l0 = 0.1;
+	double re = 1.5 * l0;
+	RefValues ref(2, l0, re);
 
-	double n0_exact = 4.0 * weight(l0, re_forGradient) + 4.0 * weight(sqrt(2.0) * l0, re_forGradient);
+	double n0_exact = 4.0 * weight(l0, re) + 4.0 * weight(sqrt(2.0) * l0, re);
+	double lambda_exact = (4.0 *(l0*l0)* weight(l0, re) + 4.0 *(2.0*l0*l0)* weight(sqrt(2.0) * l0, re)) / n0_exact;
 
-	EXPECT_DOUBLE_EQ(ref.n0_forGradient, n0_exact);
+	EXPECT_DOUBLE_EQ(ref.n0, n0_exact);
+	EXPECT_DOUBLE_EQ(ref.lambda, lambda_exact);
 }
-TEST(RefValuesTest, NumberDensityForGradientTest3d) {
-	double l0                  = 0.1;
-	double re_forNumberDensity = 2.5 * l0;
-	double re_forGradient      = 1.5 * l0;
-	double re_forLaplacian     = 3.1 * l0;
-	RefValues ref;
-	ref.calc(3, l0, re_forNumberDensity, re_forGradient, re_forLaplacian);
+TEST(RefValuesTest, test3d) {
+	double l0 = 0.1;
+	double re = 1.5 * l0;
+	RefValues ref(3, l0, re);
 
-	double n0_exact = 6.0 * weight(l0, re_forGradient) + 12.0 * weight(sqrt(2.0) * l0, re_forGradient);
-	EXPECT_DOUBLE_EQ(ref.n0_forGradient, n0_exact);
-}
-TEST(RefValuesTest, NumberDensityForLaplacianTest2d) {
-	double l0                  = 0.1;
-	double re_forNumberDensity = 2.5 * l0;
-	double re_forGradient      = 2.1 * l0;
-	double re_forLaplacian     = 1.5 * l0;
-	RefValues ref;
-	ref.calc(2, l0, re_forNumberDensity, re_forGradient, re_forLaplacian);
+	double n0_exact = 6.0 * weight(l0, re) + 12.0 * weight(sqrt(2.0) * l0, re);
+	double lambda_exact = (6.0 *(l0*l0)* weight(l0, re) + 12.0 *(2.0*l0*l0)* weight(sqrt(2.0) * l0, re)) / n0_exact;
 
-	double n0_exact = 4.0 * weight(l0, re_forLaplacian) + 4.0 * weight(sqrt(2.0) * l0, re_forLaplacian);
-	EXPECT_DOUBLE_EQ(ref.n0_forLaplacian, n0_exact);
-}
-TEST(RefValuesTest, NumberDensityForLaplacianTest3d) {
-	double l0                  = 0.1;
-	double re_forNumberDensity = 2.5 * l0;
-	double re_forGradient      = 2.1 * l0;
-	double re_forLaplacian     = 1.5 * l0;
-	RefValues ref;
-	ref.calc(3, l0, re_forNumberDensity, re_forGradient, re_forLaplacian);
-
-	double n0_exact = 6.0 * weight(l0, re_forLaplacian) + 12.0 * weight(sqrt(2.0) * l0, re_forLaplacian);
-	EXPECT_DOUBLE_EQ(ref.n0_forLaplacian, n0_exact);
+	EXPECT_DOUBLE_EQ(ref.n0, n0_exact);
+	EXPECT_DOUBLE_EQ(ref.lambda, lambda_exact);
 }


### PR DESCRIPTION
擬似的なインターフェースクラス `IPressureCalculator` を作成し、圧力計算はそのメソッド `calc` が担うようにした。
圧力ポアソン方程式を用いた半陰解法は `IPressureCalculator` を継承した実装クラス `ImplicitPressureCalculator` に処理を移動した。
`MPS` クラスは `IPressureCalculator` 型の `pressureCalculator` をメンバ変数として持ち、コンストラクタにて依存性の注入（`pressureCalculator` への実装クラスの代入）を行う