### PR TITLE
粒子の加速度をリセットするコードを修正

### DIFF
--- a/src/mps.cpp
+++ b/src/mps.cpp
@@ -104,10 +104,8 @@ void MPS::moveParticle() {
         if (p.type == ParticleType::Fluid) {
             p.velocity += p.acceleration * settings.dt;
             p.position += p.velocity * settings.dt;
-
-        } else {
-            p.acceleration.setZero();
         }
+        p.acceleration.setZero();
     }
 }
 


### PR DESCRIPTION
一回目の移動の後流体粒子の加速度をゼロにしていなかったので修正