### PR TITLE
Changed bucket length to reMax

### DIFF
--- a/src/bucket.cpp
+++ b/src/bucket.cpp
@@ -7,9 +7,9 @@ void Bucket::generate(const int& particleNum) {
     next.resize(particleNum);
 }
 
-void Bucket::set(const double& reMax, const double& CFL, const Domain& domain, const size_t& particleSize) {
+void Bucket::set(const double& reMax, const Domain& domain, const size_t& particleSize) {
 
-    length = reMax * (1.0 + CFL);
+    length = reMax;
 
     numX     = (int) (domain.xLength / length) + 3;
     numY     = (int) (domain.yLength / length) + 3;

--- a/src/bucket.hpp
+++ b/src/bucket.hpp
@@ -22,7 +22,7 @@ public:
     std::vector<int> next, first, last;
 
     void generate(const int& particleNum);
-    void set(const double& reMax, const double& CFL, const Domain& domain, const size_t& particleSize);
+    void set(const double& reMax, const Domain& domain, const size_t& particleSize);
     /**
      * @brief store particles in the bucket
      * @param particles partiles to be stored

--- a/src/mps.cpp
+++ b/src/mps.cpp
@@ -22,7 +22,7 @@ MPS::MPS(const Input& input, std::unique_ptr<PressureCalculator::Interface>&& pr
     refValuesForGradient      = RefValues(settings.dim, settings.particleDistance, settings.re_forGradient);
     refValuesForLaplacian     = RefValues(settings.dim, settings.particleDistance, settings.re_forLaplacian);
 
-    bucket.set(settings.reMax, settings.cflCondition, domain, particles.size());
+    bucket.set(settings.reMax, domain, particles.size());
 }
 
 void MPS::stepForward() {


### PR DESCRIPTION
The following is generated by GitHub Copilot.

===
This pull request includes changes in the `Bucket` class and `MPS` class in the `src/bucket.cpp`, `src/bucket.hpp`, and `src/mps.cpp` files. The main changes involve the removal of the `CFL` parameter from the `Bucket::set` method and the consequent adjustments in the method's body and its usages.

Here are the main changes:

* [`src/bucket.hpp`](diffhunk://#diff-a8d3bb02b9c52972c26a48e3b5ca3961b43e9d81a1328b88c6016e281eb44e12L25-R25): The `CFL` parameter was removed from the `Bucket::set` method declaration.
* [`src/bucket.cpp`](diffhunk://#diff-444404255c7a631d9dedd564cbc35f35b3e74d429cce2094ae999434af19a180L10-R12): The `CFL` parameter was removed from the `Bucket::set` method definition, and the formula for `length` was simplified by removing the multiplication with `CFL`.
* [`src/mps.cpp`](diffhunk://#diff-8a09091d63290b3728a937aae91caa333ca61b288ed91d3d2d4d728381b64b84L25-R25): The `CFL` argument was removed from the `bucket.set` method call in the `MPS::MPS` constructor.

These changes simplify the `Bucket` class by removing the dependency on the `CFL` condition.