### PR TITLE
add particles class

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,6 +10,7 @@ add_executable(${PROJECT_NAME}
   src/main.cpp
   src/mps.cpp
   src/particle.cpp
+  src/particles.cpp
   src/particles_exporter.cpp
   src/refvalues.cpp
   src/saver.cpp
@@ -110,6 +111,7 @@ target_link_libraries(${PROJECT_NAME} PUBLIC yaml-cpp::yaml-cpp)
 # ------------------------------
 add_library(particles STATIC
   src/particle.cpp
+  src/particles.cpp
   src/particles_exporter.cpp
 )
 target_link_libraries(particles PUBLIC Eigen3::Eigen)

--- a/generator/generate_dambreak.cpp
+++ b/generator/generate_dambreak.cpp
@@ -65,7 +65,7 @@ int main(int argc, char** argv) {
 
             if (type != ParticleType::Ghost) {
                 Eigen::Vector3d vel = Eigen::Vector3d::Zero();
-                particles.emplace_back(particles.size(), type, pos, vel);
+                particles.add(Particle(particles.size(), type, pos, vel));
             }
         }
     }

--- a/generator/generate_dambreak.cpp
+++ b/generator/generate_dambreak.cpp
@@ -1,4 +1,5 @@
 #include "../src/particle.hpp"
+#include "../src/particles.hpp"
 #include "../src/particles_exporter.hpp"
 
 #include <filesystem>
@@ -13,7 +14,7 @@ void check_fluid_range(std::vector<double>& x_range, std::vector<double>& y_rang
 bool isInside(Eigen::Vector3d& position, std::vector<double>& x_range, std::vector<double>& y_range, double& eps);
 
 int main(int argc, char** argv) {
-    std::vector<Particle> particles;
+    Particles particles;
 
     double l0  = 0.025;
     double eps = 0.01 * l0;

--- a/generator/generate_hydrostatic.cpp
+++ b/generator/generate_hydrostatic.cpp
@@ -1,4 +1,5 @@
 #include "../src/particle.hpp"
+#include "../src/particles.hpp"
 #include "../src/particles_exporter.hpp"
 
 #include <algorithm>
@@ -28,7 +29,7 @@ public:
 };
 
 int main(int argc, char** argv) {
-    std::vector<Particle> particles;
+    Particles particles;
 
     double l0 = 0.012;
 

--- a/generator/generate_hydrostatic.cpp
+++ b/generator/generate_hydrostatic.cpp
@@ -50,19 +50,19 @@ int main(int argc, char** argv) {
             }
             // fluid region
             if (fluidDomain.sdf(r) < 0) {
-                particles.push_back(Particle(id, ParticleType::Fluid, r_3d, Eigen::Vector3d::Zero()));
+                particles.add(Particle(id, ParticleType::Fluid, r_3d, Eigen::Vector3d::Zero()));
                 id++;
                 continue;
             }
             // wall region
             if (wallBB.sdf(r) < 0) {
-                particles.push_back(Particle(id, ParticleType::Wall, r_3d, Eigen::Vector3d::Zero()));
+                particles.add(Particle(id, ParticleType::Wall, r_3d, Eigen::Vector3d::Zero()));
                 id++;
                 continue;
             }
             // dummy region
             if (dummyBB.sdf(r) < 0) {
-                particles.push_back(Particle(id, ParticleType::DummyWall, r_3d, Eigen::Vector3d::Zero()));
+                particles.add(Particle(id, ParticleType::DummyWall, r_3d, Eigen::Vector3d::Zero()));
                 id++;
                 continue;
             }

--- a/src/bucket.cpp
+++ b/src/bucket.cpp
@@ -21,7 +21,7 @@ Bucket::Bucket(const double& reMax, const Domain& domain, const size_t& particle
     this->next.resize(particleSize);
 }
 
-void Bucket::storeParticles(std::vector<Particle>& particles) {
+void Bucket::storeParticles(Particles& particles) {
 
 #pragma omp parallel for
     for (int i = 0; i < num; i++) {

--- a/src/bucket.hpp
+++ b/src/bucket.hpp
@@ -2,7 +2,7 @@
 
 #include "common.hpp"
 #include "domain.hpp"
-#include "particle.hpp"
+#include "particles.hpp"
 
 #include <iostream>
 #include <vector>
@@ -31,5 +31,5 @@ public:
      * @param particles particles to be stored
      * @param domain domain of the simulation
      */
-    void storeParticles(std::vector<Particle>& particles);
+    void storeParticles(Particles& particles);
 };

--- a/src/input.hpp
+++ b/src/input.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "common.hpp"
-#include "particle.hpp"
+#include "particles.hpp"
 #include "settings.hpp"
 
 #include <vector>
@@ -10,7 +10,7 @@
  * @brief Represents the input data for MPS simulation.
  */
 struct Input {
-    Settings settings;               ///< Settings for the simulation
-    std::vector<Particle> particles; ///< Initial particles arrangement in the simulation
-    double startTime{};              ///< Start time of the simulation
+    Settings settings;   ///< Settings for the simulation
+    Particles particles; ///< Initial particles arrangement in the simulation
+    double startTime{};  ///< Start time of the simulation
 };

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -101,7 +101,7 @@ Settings Loader::loadSettingYaml(const fs::path& settingPath) {
     return s;
 }
 
-std::pair<double, std::vector<Particle>> Loader::loadParticleProf(const fs::path& profPath) {
+std::pair<double, Particles> Loader::loadParticleProf(const fs::path& profPath) {
     std::ifstream ifs;
     ifs.open(profPath);
     if (ifs.fail()) {
@@ -109,7 +109,7 @@ std::pair<double, std::vector<Particle>> Loader::loadParticleProf(const fs::path
         std::exit(-1);
     }
 
-    std::vector<Particle> particles;
+    Particles particles;
     double startTime = NAN;
     int particleSize = 0;
     ifs >> startTime;

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -125,7 +125,7 @@ std::pair<double, Particles> Loader::loadParticleProf(const fs::path& profPath) 
 
         type = static_cast<ParticleType>(type_int);
         if (type != ParticleType::Ghost) {
-            particles.emplace_back(particles.size(), type, pos, vel);
+            particles.add(Particle(particles.size(), type, pos, vel));
         }
     }
     ifs.close();

--- a/src/loader.hpp
+++ b/src/loader.hpp
@@ -2,6 +2,7 @@
 
 #include "common.hpp"
 #include "input.hpp"
+#include "particles.hpp"
 
 #include <filesystem>
 #include <utility>
@@ -22,5 +23,5 @@ public:
 private:
     Settings loadSettingYaml(const std::filesystem::path& settingPath);
 
-    std::pair<double, std::vector<Particle>> loadParticleProf(const std::filesystem::path& profPath);
+    std::pair<double, Particles> loadParticleProf(const std::filesystem::path& profPath);
 };

--- a/src/mps.hpp
+++ b/src/mps.hpp
@@ -5,6 +5,7 @@
 #include "domain.hpp"
 #include "input.hpp"
 #include "neighbor_searcher.hpp"
+#include "particles.hpp"
 #include "pressure_calculator/interface.hpp"
 #include "refvalues.hpp"
 #include "settings.hpp"
@@ -26,7 +27,7 @@ public:
     RefValues refValuesForNumberDensity; ///< Reference values for the simulation (\f$n^0\f$, \f$\lambda^0\f$)
     RefValues refValuesForLaplacian;     ///< Reference values for the simulation (\f$n^0\f$, \f$\lambda^0\f$)
     RefValues refValuesForGradient;      ///< Reference values for the simulation (\f$n^0\f$, \f$\lambda^0\f$)
-    std::vector<Particle> particles;     ///< Particles in the simulation
+    Particles particles;                 ///< Particles in the simulation
     Domain domain{};                     ///< Domain of the simulation
 
     std::unique_ptr<PressureCalculator::Interface> pressureCalculator; ///< Interface for pressure calculation

--- a/src/neighbor_searcher.cpp
+++ b/src/neighbor_searcher.cpp
@@ -8,7 +8,7 @@ NeighborSearcher::NeighborSearcher(const double& re, const Domain& domain, const
     this->bucket = Bucket(re, domain, particleSize);
 }
 
-void NeighborSearcher::setNeighbors(std::vector<Particle>& particles) {
+void NeighborSearcher::setNeighbors(Particles& particles) {
     bucket.storeParticles(particles);
 
 #pragma omp parallel for

--- a/src/neighbor_searcher.hpp
+++ b/src/neighbor_searcher.hpp
@@ -1,6 +1,6 @@
 #include "bucket.hpp"
 #include "domain.hpp"
-#include "particle.hpp"
+#include "particles.hpp"
 
 #include <vector>
 
@@ -10,7 +10,7 @@ public:
 
     NeighborSearcher(const double& re, const Domain& domain, const size_t& particleSize);
 
-    void setNeighbors(std::vector<Particle>& particles);
+    void setNeighbors(Particles& particles);
 
 private:
     double re;

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -32,3 +32,7 @@ void Particles::add(const Particle& particle) {
 Particle& Particles::operator[](size_t index) {
     return particles[index];
 }
+
+const Particle& Particles::operator[](size_t index) const {
+    return particles[index];
+}

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -21,3 +21,7 @@ std::vector<Particle>::const_iterator Particles::end() const {
 int Particles::size() {
     return particles.size();
 }
+
+void Particles::add(const Particle& particle) {
+    particles.emplace_back(particle);
+}

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -22,6 +22,14 @@ int Particles::size() {
     return particles.size();
 }
 
+int Particles::size() const {
+    return particles.size();
+}
+
 void Particles::add(const Particle& particle) {
     particles.emplace_back(particle);
+}
+
+Particle& Particles::operator[](size_t index) {
+    return particles[index];
 }

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -23,6 +23,9 @@ int Particles::size() const {
 }
 
 void Particles::add(const Particle& particle) {
+    // This class assumes that the index of the inner vector is equal to the id of the particle located there.
+    // To ensure this, assert that the id of the particle is equal to the size of the inner vector.
+    assert(particle.id == particles.size());
     particles.emplace_back(particle);
 }
 

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -18,10 +18,6 @@ std::vector<Particle>::const_iterator Particles::end() const {
     return particles.end();
 }
 
-int Particles::size() {
-    return particles.size();
-}
-
 int Particles::size() const {
     return particles.size();
 }

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -1,0 +1,19 @@
+#include "particles.hpp"
+
+#include <vector>
+
+std::vector<Particle>::iterator Particles::begin() {
+    return particles.begin();
+}
+
+std::vector<Particle>::const_iterator Particles::begin() const {
+    return particles.begin();
+}
+
+std::vector<Particle>::iterator Particles::end() {
+    return particles.end();
+}
+
+std::vector<Particle>::const_iterator Particles::end() const {
+    return particles.end();
+}

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -17,3 +17,7 @@ std::vector<Particle>::iterator Particles::end() {
 std::vector<Particle>::const_iterator Particles::end() const {
     return particles.end();
 }
+
+int Particles::size() {
+    return particles.size();
+}

--- a/src/particles.hpp
+++ b/src/particles.hpp
@@ -4,6 +4,9 @@
 
 #include <vector>
 
+/**
+ * @brief A collection of particles
+ */
 class Particles {
 public:
     // functions to make Particles iterable

--- a/src/particles.hpp
+++ b/src/particles.hpp
@@ -10,7 +10,15 @@ public:
         return particles.begin();
     }
 
+    std::vector<Particle>::const_iterator begin() const {
+        return particles.begin();
+    }
+
     std::vector<Particle>::iterator end() {
+        return particles.end();
+    }
+
+    std::vector<Particle>::const_iterator end() const {
         return particles.end();
     }
 

--- a/src/particles.hpp
+++ b/src/particles.hpp
@@ -12,7 +12,6 @@ public:
     std::vector<Particle>::iterator end();
     std::vector<Particle>::const_iterator end() const;
 
-    int size();
     int size() const;
     void add(const Particle& particle);
     Particle& operator[](size_t index);

--- a/src/particles.hpp
+++ b/src/particles.hpp
@@ -6,21 +6,11 @@
 
 class Particles {
 public:
-    std::vector<Particle>::iterator begin() {
-        return particles.begin();
-    }
-
-    std::vector<Particle>::const_iterator begin() const {
-        return particles.begin();
-    }
-
-    std::vector<Particle>::iterator end() {
-        return particles.end();
-    }
-
-    std::vector<Particle>::const_iterator end() const {
-        return particles.end();
-    }
+    // functions to make Particles iterable
+    std::vector<Particle>::iterator begin();
+    std::vector<Particle>::const_iterator begin() const;
+    std::vector<Particle>::iterator end();
+    std::vector<Particle>::const_iterator end() const;
 
 private:
     std::vector<Particle> particles;

--- a/src/particles.hpp
+++ b/src/particles.hpp
@@ -37,6 +37,14 @@ public:
      */
     Particle& operator[](size_t index);
 
+    /**
+     * @brief Get a particle by index
+     *
+     * @param index the index of the particle
+     * @return const Particle& the particle
+     */
+    const Particle& operator[](size_t index) const;
+
 private:
     std::vector<Particle> particles;
 };

--- a/src/particles.hpp
+++ b/src/particles.hpp
@@ -1,0 +1,19 @@
+#pragma once
+
+#include "particle.hpp"
+
+#include <vector>
+
+class Particles {
+public:
+    std::vector<Particle>::iterator begin() {
+        return particles.begin();
+    }
+
+    std::vector<Particle>::iterator end() {
+        return particles.end();
+    }
+
+private:
+    std::vector<Particle> particles;
+};

--- a/src/particles.hpp
+++ b/src/particles.hpp
@@ -13,6 +13,7 @@ public:
     std::vector<Particle>::const_iterator end() const;
 
     int size();
+    void add(const Particle& particle);
 
 private:
     std::vector<Particle> particles;

--- a/src/particles.hpp
+++ b/src/particles.hpp
@@ -12,8 +12,26 @@ public:
     std::vector<Particle>::iterator end();
     std::vector<Particle>::const_iterator end() const;
 
+    /**
+     * @brief Get the number of particles
+     *
+     * @return int the number of particles
+     */
     int size() const;
+
+    /**
+     * @brief Add a particle to the collection
+     *
+     * @param particle the particle to add
+     */
     void add(const Particle& particle);
+
+    /**
+     * @brief Get a particle by index
+     *
+     * @param index the index of the particle
+     * @return Particle& the particle
+     */
     Particle& operator[](size_t index);
 
 private:

--- a/src/particles.hpp
+++ b/src/particles.hpp
@@ -13,7 +13,9 @@ public:
     std::vector<Particle>::const_iterator end() const;
 
     int size();
+    int size() const;
     void add(const Particle& particle);
+    Particle& operator[](size_t index);
 
 private:
     std::vector<Particle> particles;

--- a/src/particles.hpp
+++ b/src/particles.hpp
@@ -12,6 +12,8 @@ public:
     std::vector<Particle>::iterator end();
     std::vector<Particle>::const_iterator end() const;
 
+    int size();
+
 private:
     std::vector<Particle> particles;
 };

--- a/src/particles_exporter.cpp
+++ b/src/particles_exporter.cpp
@@ -9,7 +9,7 @@ using std::cerr;
 using std::endl;
 namespace fs = std::filesystem;
 
-void ParticlesExporter::setParticles(const std::vector<Particle>& particles) {
+void ParticlesExporter::setParticles(const Particles& particles) {
     this->particles = particles;
 }
 

--- a/src/particles_exporter.hpp
+++ b/src/particles_exporter.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
 #include "common.hpp"
-#include "particle.hpp"
+#include "particles.hpp"
 
 #include <filesystem>
 #include <fstream>
@@ -18,9 +18,9 @@
  */
 class ParticlesExporter {
 public:
-    std::vector<Particle> particles;
+    Particles particles;
 
-    void setParticles(const std::vector<Particle>& particles);
+    void setParticles(const Particles& particles);
     void toProf(const std::filesystem::path& path, const double& time);
     void toVtu(const std::filesystem::path& path, const double& time, const double& n0ForNumberDensity = 1.0);
 

--- a/src/pressure_calculator/explicit.cpp
+++ b/src/pressure_calculator/explicit.cpp
@@ -13,7 +13,7 @@ Explicit::Explicit(double fluidDensity, double re, double soundSpeed, int dimens
 Explicit::~Explicit() {
 }
 
-std::vector<double> Explicit::calc(const std::vector<Particle>& particles) {
+std::vector<double> Explicit::calc(const Particles& particles) {
     std::vector<double> pressure;
     pressure.resize(particles.size());
 

--- a/src/pressure_calculator/explicit.cpp
+++ b/src/pressure_calculator/explicit.cpp
@@ -18,7 +18,7 @@ std::vector<double> Explicit::calc(const Particles& particles) {
     pressure.resize(particles.size());
 
 #pragma omp parallel for
-    for (auto& pi : particles) {
+    for (const auto& pi : particles) {
         if (pi.type == ParticleType::Ghost) {
             pressure[pi.id] = 0;
         } else {

--- a/src/pressure_calculator/explicit.hpp
+++ b/src/pressure_calculator/explicit.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../particle.hpp"
+#include "../particles.hpp"
 #include "interface.hpp"
 
 #include <vector>
@@ -13,7 +13,7 @@ public:
      * @brief calculate pressure
      * @param particles particles
      */
-    std::vector<double> calc(const std::vector<Particle>& particles) override;
+    std::vector<double> calc(const Particles& particles) override;
     ~Explicit() override;
 
     Explicit(double fluidDensity, double n0, double soundSpeed, int dimension, double particleDistance);

--- a/src/pressure_calculator/implicit.cpp
+++ b/src/pressure_calculator/implicit.cpp
@@ -31,7 +31,7 @@ Implicit::Implicit(
     this->refValuesForLaplacian     = RefValues(dimension, particleDistance, reForLaplacian);
 }
 
-std::vector<double> Implicit::calc(const std::vector<Particle>& particles) {
+std::vector<double> Implicit::calc(const Particles& particles) {
     this->particles = particles;
     setSourceTerm();
     setMatrix();

--- a/src/pressure_calculator/implicit.hpp
+++ b/src/pressure_calculator/implicit.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../particle.hpp"
+#include "../particles.hpp"
 #include "../refvalues.hpp"
 #include "interface.hpp"
 
@@ -15,7 +15,7 @@ public:
      * @brief calculate pressure
      * @param particles particles
      */
-    std::vector<double> calc(const std::vector<Particle>& particles) override;
+    std::vector<double> calc(const Particles& particles) override;
     ~Implicit() override;
 
     Implicit(
@@ -40,7 +40,7 @@ private:
     double compressibility;
     double relaxationCoefficient;
 
-    std::vector<Particle> particles;
+    Particles particles;
 
     Eigen::SparseMatrix<double, Eigen::RowMajor>
         coefficientMatrix;      ///< Coefficient matrix for pressure Poisson equation

--- a/src/pressure_calculator/interface.hpp
+++ b/src/pressure_calculator/interface.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../particle.hpp"
+#include "../particles.hpp"
 
 #include <vector>
 
@@ -20,7 +20,7 @@ public:
      *
      * @return pressures of particles
      */
-    virtual std::vector<double> calc(const std::vector<Particle>& particles) = 0;
+    virtual std::vector<double> calc(const Particles& particles) = 0;
 
     /**
      * @brief destructor

--- a/src/pressure_calculator/pressure_poisson_equation.cpp
+++ b/src/pressure_calculator/pressure_poisson_equation.cpp
@@ -31,7 +31,7 @@ PressurePoissonEquation::PressurePoissonEquation(
 }
 
 void PressurePoissonEquation::setup(
-    const std::vector<Particle>& particles, const std::function<bool(const Particle&)>& isPressureUpdateTarget
+    const Particles& particles, const std::function<bool(const Particle&)>& isPressureUpdateTarget
 ) {
     this->particlesCount = particles.size();
 
@@ -73,7 +73,7 @@ void PressurePoissonEquation::resetEquation() {
  * update
  */
 void PressurePoissonEquation::setSourceTerm(
-    const std::vector<Particle>& particles, const std::function<bool(const Particle&)>& isPressureUpdateTarget
+    const Particles& particles, const std::function<bool(const Particle&)>& isPressureUpdateTarget
 ) {
     double n0    = this->n0_forNumberDensity;
     double gamma = this->relaxationCoefficient;
@@ -98,7 +98,7 @@ void PressurePoissonEquation::setSourceTerm(
  * update
  */
 void PressurePoissonEquation::setMatrixTriplets(
-    const std::vector<Particle>& particles, const std::function<bool(const Particle&)>& isPressureUpdateTarget
+    const Particles& particles, const std::function<bool(const Particle&)>& isPressureUpdateTarget
 ) {
     auto a  = 2.0 * dimension / (n0_forLaplacian * lambda0);
     auto re = reForLaplacian;

--- a/src/pressure_calculator/pressure_poisson_equation.hpp
+++ b/src/pressure_calculator/pressure_poisson_equation.hpp
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "../particle.hpp"
+#include "../particles.hpp"
 
 #include <Eigen/Sparse>
 #include <vector>
@@ -33,8 +33,7 @@ public:
      * @param isPressureUpdateTarget Function that gets a particle and returns true if the particle is a target for
      * pressure update
      */
-    void
-    setup(const std::vector<Particle>& particles, const std::function<bool(const Particle&)>& isPressureUpdateTarget);
+    void setup(const Particles& particles, const std::function<bool(const Particle&)>& isPressureUpdateTarget);
 
     /**
      * @brief Solve pressure Poisson equation
@@ -61,12 +60,9 @@ private:
     Eigen::VectorXd sourceTerm; ///< Source term for pressure Poisson equation
 
     void resetEquation();
-    void setSourceTerm(
-        const std::vector<Particle>& particles, const std::function<bool(const Particle&)>& isPressureUpdateTarget
-    );
-    void setMatrixTriplets(
-        const std::vector<Particle>& particles, const std::function<bool(const Particle&)>& isPressureUpdateTarget
-    );
+    void setSourceTerm(const Particles& particles, const std::function<bool(const Particle&)>& isPressureUpdateTarget);
+    void
+    setMatrixTriplets(const Particles& particles, const std::function<bool(const Particle&)>& isPressureUpdateTarget);
 };
 
 } // namespace PressureCalculator


### PR DESCRIPTION
Close #77 

- Particles クラスを実装
- std::vector<Particle> を Particles に変更
- CMakeLists に particles を追加
