### PR TITLE
Add PressureCalculator::DirichletBoundaryCondition

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,6 +18,7 @@ add_executable(${PROJECT_NAME}
   src/pressure_calculator/implicit.cpp
   src/pressure_calculator/explicit.cpp
   src/pressure_calculator/pressure_poisson_equation.cpp
+  src/pressure_calculator/dirichlet_boundary_condition.cpp
   src/neighbor_searcher.cpp
 )
 

--- a/src/pressure_calculator/dirichlet_boundary_condition.cpp
+++ b/src/pressure_calculator/dirichlet_boundary_condition.cpp
@@ -1,0 +1,15 @@
+#include "dirichlet_boundary_condition.hpp"
+
+using PressureCalculator::DirichletBoundaryCondition;
+
+bool DirichletBoundaryCondition::contains(int id) const {
+    return this->values.find(id) != this->values.end();
+}
+
+double DirichletBoundaryCondition::value(int id) const {
+    return this->values.at(id);
+}
+
+void DirichletBoundaryCondition::set(int id, double value) {
+    this->values[id] = value;
+}

--- a/src/pressure_calculator/dirichlet_boundary_condition.hpp
+++ b/src/pressure_calculator/dirichlet_boundary_condition.hpp
@@ -4,6 +4,13 @@
 
 namespace PressureCalculator {
 
+/**
+ * @brief Dirichlet boundary condition
+ *
+ * @details Dirichlet boundary condition is used to set the pressure of particles on the boundary of the fluid domain.
+ * This class controls the id of particles that attach Dirichlet boundary conditions and the value of pressure for those
+ * particles.
+ */
 class DirichletBoundaryCondition {
 public:
     /**

--- a/src/pressure_calculator/dirichlet_boundary_condition.hpp
+++ b/src/pressure_calculator/dirichlet_boundary_condition.hpp
@@ -6,8 +6,25 @@ namespace PressureCalculator {
 
 class DirichletBoundaryCondition {
 public:
+    /**
+     * @brief Check if the boundary condition contains the particle
+     * @param id Particle id
+     * @return True if the boundary condition contains the particle
+     */
     bool contains(int id) const;
+
+    /**
+     * @brief Get the boundary condition value
+     * @param id Particle id
+     * @return Boundary condition value
+     */
     double value(int id) const;
+
+    /**
+     * @brief Set the boundary condition value
+     * @param id Particle id
+     * @param value Boundary condition value
+     */
     void set(int id, double value);
 
     DirichletBoundaryCondition() = default;

--- a/src/pressure_calculator/dirichlet_boundary_condition.hpp
+++ b/src/pressure_calculator/dirichlet_boundary_condition.hpp
@@ -1,0 +1,25 @@
+#pragma once
+
+#include <unordered_map>
+
+namespace PressureCalculator {
+
+class DirichletBoundaryCondition {
+public:
+    bool contains(int id) const;
+    double value(int id) const;
+    void set(int id, double value);
+
+    DirichletBoundaryCondition() = default;
+
+private:
+    /**
+     * @brief boundary condition values
+     *
+     * key: particle id
+     * value: boundary condition value
+     */
+    std::unordered_map<int, double> values;
+};
+
+} // namespace PressureCalculator

--- a/src/pressure_calculator/implicit.cpp
+++ b/src/pressure_calculator/implicit.cpp
@@ -37,7 +37,7 @@ Implicit::Implicit(
 }
 
 std::vector<double> Implicit::calc(const std::vector<Particle>& particles) {
-    // Boundary condition: Pressure update is performed only for inner particles.
+    // Boundary condition: Particles other than inner particles set pressure to 0
     DirichletBoundaryCondition dirichletBoundaryCondition;
     for (const auto& p : particles) {
         if (p.boundaryCondition != FluidState::Inner) {

--- a/src/pressure_calculator/implicit.cpp
+++ b/src/pressure_calculator/implicit.cpp
@@ -38,9 +38,14 @@ Implicit::Implicit(
 
 std::vector<double> Implicit::calc(const std::vector<Particle>& particles) {
     // Boundary condition: Pressure update is performed only for inner particles.
-    auto isPressureUpdateTarget = [](const Particle& p) { return p.boundaryCondition == FluidState::Inner; };
+    DirichletBoundaryCondition dirichletBoundaryCondition;
+    for (const auto& p : particles) {
+        if (p.boundaryCondition != FluidState::Inner) {
+            dirichletBoundaryCondition.set(p.id, 0.0);
+        }
+    }
 
-    this->pressurePoissonEquation.setup(particles, isPressureUpdateTarget);
+    this->pressurePoissonEquation.setup(particles, dirichletBoundaryCondition);
     this->pressure = this->pressurePoissonEquation.solve();
     removeNegativePressure();
 

--- a/src/pressure_calculator/pressure_poisson_equation.cpp
+++ b/src/pressure_calculator/pressure_poisson_equation.cpp
@@ -81,6 +81,7 @@ void PressurePoissonEquation::setSourceTerm(
 #pragma omp parallel for
     for (auto& pi : particles) {
         if (dirichletBoundaryCondition.contains(pi.id)) {
+            // When dirichlet boundary condition is set, the source term is the boundary condition value.
             sourceTerm[pi.id] = dirichletBoundaryCondition.value(pi.id);
         } else {
             sourceTerm[pi.id] = gamma * (1.0 / (dt * dt)) * ((pi.numberDensity - n0) / n0);
@@ -105,6 +106,8 @@ void PressurePoissonEquation::setMatrixTriplets(
 
     for (auto& pi : particles) {
         if (dirichletBoundaryCondition.contains(pi.id)) {
+            // When Dirichlet boundary conditions are set, only the diagonal term is set to 1 so that the pressure is at
+            // the specified value.
             matrixTriplets.emplace_back(pi.id, pi.id, 1.0);
             continue;
         }

--- a/src/pressure_calculator/pressure_poisson_equation.hpp
+++ b/src/pressure_calculator/pressure_poisson_equation.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "../particle.hpp"
+#include "dirichlet_boundary_condition.hpp"
 
 #include <Eigen/Sparse>
 #include <vector>
@@ -33,8 +34,7 @@ public:
      * @param isPressureUpdateTarget Function that gets a particle and returns true if the particle is a target for
      * pressure update
      */
-    void
-    setup(const std::vector<Particle>& particles, const std::function<bool(const Particle&)>& isPressureUpdateTarget);
+    void setup(const std::vector<Particle>& particles, const DirichletBoundaryCondition& dirichletBoundaryCondition);
 
     /**
      * @brief Solve pressure Poisson equation
@@ -61,11 +61,10 @@ private:
     Eigen::VectorXd sourceTerm; ///< Source term for pressure Poisson equation
 
     void resetEquation();
-    void setSourceTerm(
-        const std::vector<Particle>& particles, const std::function<bool(const Particle&)>& isPressureUpdateTarget
-    );
+    void
+    setSourceTerm(const std::vector<Particle>& particles, const DirichletBoundaryCondition& dirichletBoundaryCondition);
     void setMatrixTriplets(
-        const std::vector<Particle>& particles, const std::function<bool(const Particle&)>& isPressureUpdateTarget
+        const std::vector<Particle>& particles, const DirichletBoundaryCondition& dirichletBoundaryCondition
     );
 };
 


### PR DESCRIPTION
Close #114 

現状のポアソン方程式では、isPressureUpdateTarget を使って更新対象ならポアソン方程式を元に更新する、というふうにしているが、物理的には逆にターゲットではない方にディリクレ境界条件を付しているということに気づいた。
これをコード上で表現する。