### PR TITLE
update the use of exceptions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,8 +13,19 @@ Thank you for considering contributing to MPS-Basic! We appreciate your interest
 ## Guidelines
 
 - **C++ Standard**: We adhere to C++17.
-- **Exceptions**: Do **NOT** use exceptions.
 - **Use range-based for `for (auto& e : v)` instead of `for (int i = 0; i < n; i++) `, whenever it is possible**.
+
+### Exceptions 
+Do **NOT** use exceptions in MPS-Basic. However, some libraries may use exceptions internally. In that case, **you need to catch the exceptions as soon as possible** and quit the program. Also, you need to show **where the exception is thrown** in the error message.
+
+Exception is a feature of C++, which stops subsequent code execution and jumps to the dedicated block to handle the error. It is useful in some cases, but it has disadvantages.
+- Advantages
+  - clear meanings of telling errors
+- Disadvantages
+  - It stops everything, which makes memory management difficult.
+  - Unless you catch the exception, it will propagate to the uppper level, which makes it difficult to debug.
+
+So, we decided not to use exceptions in MPS-Basic.
 
 ### Macros
 - Currently no macros are approved.


### PR DESCRIPTION
close #84

-  MPS-Basicのコードでは例外を出さない
    -  例外を受け取ったらその場で処理して、プログラムを終了させる
    -  どこで例外が起こったか明らかにする
- 説明
    - 例外は通常の処理をすべて中断して呼び出し元にエラーを出す機能
    - 例外の長所
        - 失敗を明確に伝えられる手段
    - 例外の短所
        - すべてを中断するのでメモリーリークが起きやすい
        - 例外は伝播するので対応箇所が増える

