### PR TITLE
131 give the particle class the density of the fluid

### DIFF
--- a/generator/generate_dambreak.cpp
+++ b/generator/generate_dambreak.cpp
@@ -16,8 +16,9 @@ bool isInside(Eigen::Vector3d& position, std::vector<double>& x_range, std::vect
 int main(int argc, char** argv) {
     Particles particles;
 
-    double l0  = 0.025;
-    double eps = 0.01 * l0;
+    double l0      = 0.025;
+    double eps     = 0.01 * l0;
+    double density = 1000.0;
 
     std::vector<double> fluid_x_range{0.0, 1.0};
     std::vector<double> fluid_y_range{0.0, 0.6};
@@ -65,7 +66,7 @@ int main(int argc, char** argv) {
 
             if (type != ParticleType::Ghost) {
                 Eigen::Vector3d vel = Eigen::Vector3d::Zero();
-                particles.add(Particle(particles.size(), type, pos, vel, 1000.0));
+                particles.add(Particle(particles.size(), type, pos, vel, density));
             }
         }
     }

--- a/generator/generate_dambreak.cpp
+++ b/generator/generate_dambreak.cpp
@@ -65,7 +65,7 @@ int main(int argc, char** argv) {
 
             if (type != ParticleType::Ghost) {
                 Eigen::Vector3d vel = Eigen::Vector3d::Zero();
-                particles.add(Particle(particles.size(), type, pos, vel));
+                particles.add(Particle(particles.size(), type, pos, vel, 1000.0));
             }
         }
     }

--- a/generator/generate_hydrostatic.cpp
+++ b/generator/generate_hydrostatic.cpp
@@ -50,19 +50,19 @@ int main(int argc, char** argv) {
             }
             // fluid region
             if (fluidDomain.sdf(r) < 0) {
-                particles.add(Particle(id, ParticleType::Fluid, r_3d, Eigen::Vector3d::Zero()));
+                particles.add(Particle(id, ParticleType::Fluid, r_3d, Eigen::Vector3d::Zero(), 1000.0));
                 id++;
                 continue;
             }
             // wall region
             if (wallBB.sdf(r) < 0) {
-                particles.add(Particle(id, ParticleType::Wall, r_3d, Eigen::Vector3d::Zero()));
+                particles.add(Particle(id, ParticleType::Wall, r_3d, Eigen::Vector3d::Zero(), 1000.0));
                 id++;
                 continue;
             }
             // dummy region
             if (dummyBB.sdf(r) < 0) {
-                particles.add(Particle(id, ParticleType::DummyWall, r_3d, Eigen::Vector3d::Zero()));
+                particles.add(Particle(id, ParticleType::DummyWall, r_3d, Eigen::Vector3d::Zero(), 1000.0));
                 id++;
                 continue;
             }

--- a/generator/generate_hydrostatic.cpp
+++ b/generator/generate_hydrostatic.cpp
@@ -31,7 +31,8 @@ public:
 int main(int argc, char** argv) {
     Particles particles;
 
-    double l0 = 0.012;
+    double l0      = 0.012;
+    double density = 1000.0;
 
     Box2d fluidDomain(-0.18, 0.18, 0, 0.48);
     Box2d emptyDomain(-0.18, 0.18, 0.48, 0.6);
@@ -50,19 +51,19 @@ int main(int argc, char** argv) {
             }
             // fluid region
             if (fluidDomain.sdf(r) < 0) {
-                particles.add(Particle(id, ParticleType::Fluid, r_3d, Eigen::Vector3d::Zero(), 1000.0));
+                particles.add(Particle(id, ParticleType::Fluid, r_3d, Eigen::Vector3d::Zero(), density));
                 id++;
                 continue;
             }
             // wall region
             if (wallBB.sdf(r) < 0) {
-                particles.add(Particle(id, ParticleType::Wall, r_3d, Eigen::Vector3d::Zero(), 1000.0));
+                particles.add(Particle(id, ParticleType::Wall, r_3d, Eigen::Vector3d::Zero(), density));
                 id++;
                 continue;
             }
             // dummy region
             if (dummyBB.sdf(r) < 0) {
-                particles.add(Particle(id, ParticleType::DummyWall, r_3d, Eigen::Vector3d::Zero(), 1000.0));
+                particles.add(Particle(id, ParticleType::DummyWall, r_3d, Eigen::Vector3d::Zero(), density));
                 id++;
                 continue;
             }

--- a/input/dambreak/settings.yml
+++ b/input/dambreak/settings.yml
@@ -12,7 +12,7 @@ domainMin: [-0.1, -0.1, 0.0]
 domainMax: [1.1, 2.0, 0.0]
 
 # physical properties
-fluidDensity: 1000.0
+defaultDensity: 1000.0 # If the particle density is not specified, this value is used.
 kinematicViscosity: 1.0e-06 # 少数第一位まで書かないと文字列として認識されてしまう
 
 # gravity

--- a/input/hydrostatic/settings.yml
+++ b/input/hydrostatic/settings.yml
@@ -12,7 +12,7 @@ domainMin: [-0.25, -0.05, 0.0]
 domainMax: [0.25, 0.6, 0.0]
 
 # physical properties
-fluidDensity: 1000.0
+defaultDensity: 1000.0 # If the particle density is not specified, this value is used.
 kinematicViscosity: 1.0e-04 # 少数第一位まで書かないと文字列として認識されてしまう
 
 # gravity

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -20,7 +20,7 @@ Input Loader::load(const fs::path& settingPath, const fs::path& outputDirectory)
 
     auto particlesPath          = input.settings.particlesPath;
     this->particlesLoader       = getParticlesLoader(particlesPath);
-    auto [startTime, particles] = this->particlesLoader->load(particlesPath);
+    auto [startTime, particles] = this->particlesLoader->load(particlesPath, input.settings.defaultDensity);
     input.startTime             = startTime;
     input.particles             = particles;
 

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -79,7 +79,7 @@ Settings Loader::loadSettingYaml(const fs::path& settingPath) {
     s.numPhysicalCores = yaml["numPhysicalCores"].as<int>();
 
     // physical properties
-    s.fluidDensity       = yaml["fluidDensity"].as<double>();
+    s.defaultDensity     = yaml["defaultDensity"].as<double>();
     s.kinematicViscosity = yaml["kinematicViscosity"].as<double>();
 
     // gravity

--- a/src/mps.cpp
+++ b/src/mps.cpp
@@ -121,8 +121,8 @@ void MPS::collision() {
 
             if (neighbor.distance < settings.collisionDistance) {
 
-                double invMi = pi.inverseDensityForCollision();
-                double invMj = pj.inverseDensityForCollision();
+                double invMi = pi.inverseDensity();
+                double invMj = pj.inverseDensity();
                 double mass  = 1.0 / (invMi + invMj);
 
                 Eigen::Vector3d normal = (pj.position - pi.position).normalized();

--- a/src/mps.cpp
+++ b/src/mps.cpp
@@ -121,8 +121,8 @@ void MPS::collision() {
 
             if (neighbor.distance < settings.collisionDistance) {
 
-                double invMi = pi.inverseDensity(settings.fluidDensity);
-                double invMj = pj.inverseDensity(settings.fluidDensity);
+                double invMi = pi.inverseDensityForCollision();
+                double invMj = pj.inverseDensityForCollision();
                 double mass  = 1.0 / (invMi + invMj);
 
                 Eigen::Vector3d normal = (pj.position - pi.position).normalized();
@@ -222,7 +222,7 @@ void MPS::calPressureGradient(const double& re) {
             }
         }
         grad *= a;
-        pi.acceleration -= grad * pi.inverseDensity(settings.fluidDensity);
+        pi.acceleration -= grad / pi.density;
     }
 }
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -8,13 +8,13 @@ Particle::Particle(int id, ParticleType type, Eigen::Vector3d pos, Eigen::Vector
     this->fluidType = fluidType;
 }
 
-double Particle::inverseDensity(double& density) const {
+double Particle::inverseDensityForCollision() const {
     switch (type) {
     case ParticleType::Ghost:
         return std::numeric_limits<double>::infinity();
 
     case ParticleType::Fluid:
-        return 1 / density;
+        return 1 / this->density;
 
     case ParticleType::Wall:
     case ParticleType::DummyWall:

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -1,10 +1,11 @@
 #include "particle.hpp"
 
-Particle::Particle(int id, ParticleType type, Eigen::Vector3d pos, Eigen::Vector3d vel, int fluidType) {
+Particle::Particle(int id, ParticleType type, Eigen::Vector3d pos, Eigen::Vector3d vel, double density, int fluidType) {
     this->id        = id;
     this->type      = type;
     this->position  = pos;
     this->velocity  = vel;
+    this->density   = density;
     this->fluidType = fluidType;
 }
 

--- a/src/particle.cpp
+++ b/src/particle.cpp
@@ -9,16 +9,14 @@ Particle::Particle(int id, ParticleType type, Eigen::Vector3d pos, Eigen::Vector
     this->fluidType = fluidType;
 }
 
-double Particle::inverseDensityForCollision() const {
+double Particle::inverseDensity() const {
     switch (type) {
-    case ParticleType::Ghost:
-        return std::numeric_limits<double>::infinity();
-
     case ParticleType::Fluid:
         return 1 / this->density;
 
     case ParticleType::Wall:
     case ParticleType::DummyWall:
+    case ParticleType::Ghost:
     default:
         return 0;
     }

--- a/src/particle.hpp
+++ b/src/particle.hpp
@@ -83,5 +83,5 @@ public:
      * collision process. You should not use this function outside of the collision process. If you want to, you should
      * change this function name correctly.
      */
-    double inverseDensityForCollision() const;
+    double inverseDensity() const;
 };

--- a/src/particle.hpp
+++ b/src/particle.hpp
@@ -71,8 +71,10 @@ public:
      * @param type  type of the particle
      * @param pos  position of the particle
      * @param vel 	velocity of the particle
+     * @param density density of the particle
+     * @param fluidType type of the fluid (optional). Default value is 0.
      */
-    Particle(int id, ParticleType type, Eigen::Vector3d pos, Eigen::Vector3d vel, int fluidType = 0);
+    Particle(int id, ParticleType type, Eigen::Vector3d pos, Eigen::Vector3d vel, double density, int fluidType = 0);
 
     /**
      * @brief calculate inverse of density for collision

--- a/src/particle.hpp
+++ b/src/particle.hpp
@@ -57,6 +57,7 @@ public:
     Eigen::Vector3d acceleration = Eigen::Vector3d::Zero(); ///< acceleration of the particle
     double pressure              = 0;                       ///< pressure of the particle
     double numberDensity         = 0;                       ///< number density of the particle
+    double density               = 0; ///< density of the particle. It is used only for fluid and wall particles.
 
     FluidState boundaryCondition = FluidState::Ignored; ///< boundary condition of the particle
     double sourceTerm            = 0;                   ///< source term of the particle
@@ -74,9 +75,11 @@ public:
     Particle(int id, ParticleType type, Eigen::Vector3d pos, Eigen::Vector3d vel, int fluidType = 0);
 
     /**
-     * @brief calculate inverse of density
-     * @param density density of the particle
+     * @brief calculate inverse of density for collision
      * @return inverse of density
+     * @warning This function returns 0 for wall particles. This is because we don't want to move wall particles in the
+     * collision process. You should not use this function outside of the collision process. If you want to, you should
+     * change this function name correctly.
      */
-    double inverseDensity(double& density) const;
+    double inverseDensityForCollision() const;
 };

--- a/src/particles_loader/csv.cpp
+++ b/src/particles_loader/csv.cpp
@@ -15,20 +15,24 @@ using std::endl;
 Csv::Csv() {
 }
 
-std::pair<double, Particles> Csv::load(const fs::path& path) {
-    io::CSVReader<8> in(path.string());
+std::pair<double, Particles> Csv::load(const fs::path& path, double defaultDensity) {
+    io::CSVReader<9> in(path.string());
     double startTime    = std::stod(in.next_line());
     double numParticles = std::stod(in.next_line());
 
-    in.read_header(io::ignore_missing_column, "type", "fluidType", "x", "y", "z", "vx", "vy", "vz");
+    in.read_header(io::ignore_missing_column, "type", "fluidType", "x", "y", "z", "vx", "vy", "vz", "density");
     int type;
     int fluidType = 0;
     double x, y, z, vx, vy, vz;
+    double density = -1.0;
     Particles particles;
-    while (in.read_row(type, fluidType, x, y, z, vx, vy, vz)) {
+    while (in.read_row(type, fluidType, x, y, z, vx, vy, vz, density)) {
         Eigen::Vector3d pos(x, y, z);
         Eigen::Vector3d vel(vx, vy, vz);
-        particles.add(Particle(particles.size(), static_cast<ParticleType>(type), pos, vel, fluidType));
+        if (density < 0) {
+            density = defaultDensity;
+        }
+        particles.add(Particle(particles.size(), static_cast<ParticleType>(type), pos, vel, density, fluidType));
     }
 
     return std::make_pair(startTime, particles);

--- a/src/particles_loader/csv.hpp
+++ b/src/particles_loader/csv.hpp
@@ -10,7 +10,7 @@ namespace ParticlesLoader {
  */
 class Csv : public Interface {
 public:
-    std::pair<double, Particles> load(const fs::path& path) override;
+    std::pair<double, Particles> load(const fs::path& path, double defaultDensity) override;
     ~Csv() override;
     Csv();
 };

--- a/src/particles_loader/interface.hpp
+++ b/src/particles_loader/interface.hpp
@@ -11,9 +11,11 @@ class Interface {
 public:
     /**
      * @brief Load particles
+     * @param path Path to the particles file
+     * @param defaultDensity Default density of particles
      * @return Pair of simulation start time and particles
      */
-    virtual std::pair<double, Particles> load(const fs::path& path) = 0;
-    virtual ~Interface()                                            = default;
+    virtual std::pair<double, Particles> load(const fs::path& path, double defaultDensity) = 0;
+    virtual ~Interface()                                                                   = default;
 };
 } // namespace ParticlesLoader

--- a/src/particles_loader/prof.cpp
+++ b/src/particles_loader/prof.cpp
@@ -10,7 +10,7 @@ using std::endl;
 Prof::Prof() {
 }
 
-std::pair<double, Particles> Prof::load(const fs::path& path) {
+std::pair<double, Particles> Prof::load(const fs::path& path, double defaultDensity) {
     std::ifstream ifs;
     ifs.open(path);
     if (ifs.fail()) {
@@ -33,7 +33,7 @@ std::pair<double, Particles> Prof::load(const fs::path& path) {
         ifs >> vel.x() >> vel.y() >> vel.z();
 
         type = static_cast<ParticleType>(type_int);
-        particles.add(Particle(particles.size(), type, pos, vel));
+        particles.add(Particle(particles.size(), type, pos, vel, defaultDensity));
     }
 
     return {startTime, particles};

--- a/src/particles_loader/prof.hpp
+++ b/src/particles_loader/prof.hpp
@@ -10,7 +10,7 @@ namespace ParticlesLoader {
  */
 class Prof : public Interface {
 public:
-    std::pair<double, Particles> load(const fs::path& path) override;
+    std::pair<double, Particles> load(const fs::path& path, double defaultDensity) override;
     ~Prof() override;
     Prof();
 };

--- a/src/pressure_calculator/explicit.cpp
+++ b/src/pressure_calculator/explicit.cpp
@@ -4,10 +4,9 @@
 
 using PressureCalculator::Explicit;
 
-Explicit::Explicit(double fluidDensity, double re, double soundSpeed, int dimension, double particleDistance) {
-    this->fluidDensity = fluidDensity;
-    this->soundSpeed   = soundSpeed;
-    this->n0           = RefValues(dimension, particleDistance, re).n0;
+Explicit::Explicit(double re, double soundSpeed, int dimension, double particleDistance) {
+    this->soundSpeed = soundSpeed;
+    this->n0         = RefValues(dimension, particleDistance, re).n0;
 }
 
 Explicit::~Explicit() {
@@ -24,7 +23,7 @@ std::vector<double> Explicit::calc(Particles& particles) {
         } else {
             auto ni  = pi.numberDensity;
             auto c   = this->soundSpeed;
-            auto rho = this->fluidDensity;
+            auto rho = pi.density;
 
             if (ni > n0) {
                 pressure[pi.id] = c * c * rho * (ni - n0) / n0;

--- a/src/pressure_calculator/explicit.hpp
+++ b/src/pressure_calculator/explicit.hpp
@@ -20,10 +20,9 @@ public:
     std::vector<double> calc(Particles& particles) override;
     ~Explicit() override;
 
-    Explicit(double fluidDensity, double n0, double soundSpeed, int dimension, double particleDistance);
+    Explicit(double n0, double soundSpeed, int dimension, double particleDistance);
 
 private:
-    double fluidDensity;
     double n0;
     double soundSpeed;
 };

--- a/src/pressure_calculator/implicit.cpp
+++ b/src/pressure_calculator/implicit.cpp
@@ -16,7 +16,6 @@ Implicit::Implicit(
     double reForNumberDensity,
     double reForLaplacian,
     double dt,
-    double fluidDensity,
     double compressibility,
     double relaxationCoefficient,
     std::unique_ptr<DirichletBoundaryConditionGenerator::Interface>&& dirichletBoundaryConditionGenerator
@@ -28,7 +27,6 @@ Implicit::Implicit(
         dimension,
         dt,
         relaxationCoefficient,
-        fluidDensity,
         compressibility,
         refValuesForNumberDensity.n0,
         refValuesForLaplacian.n0,

--- a/src/pressure_calculator/implicit.hpp
+++ b/src/pressure_calculator/implicit.hpp
@@ -33,7 +33,6 @@ public:
         double re_forGradient,
         double re_forLaplacian,
         double dt,
-        double fluidDensity,
         double compressibility,
         double relaxationCoefficient,
         std::unique_ptr<DirichletBoundaryConditionGenerator::Interface>&& dirichletBoundaryConditionGenerator

--- a/src/pressure_calculator/pressure_poisson_equation.cpp
+++ b/src/pressure_calculator/pressure_poisson_equation.cpp
@@ -10,7 +10,6 @@ PressurePoissonEquation::PressurePoissonEquation(
     int dimension,
     double dt,
     double relaxationCoefficient,
-    double fluidDensity,
     double compressibility,
     double n0_forNumberDensity,
     double n0_forLaplacian,
@@ -21,7 +20,6 @@ PressurePoissonEquation::PressurePoissonEquation(
     this->dimension             = dimension;
     this->dt                    = dt;
     this->relaxationCoefficient = relaxationCoefficient;
-    this->fluidDensity          = fluidDensity;
     this->compressibility       = compressibility;
     this->n0_forNumberDensity   = n0_forNumberDensity;
     this->n0_forLaplacian       = n0_forLaplacian;
@@ -120,7 +118,7 @@ void PressurePoissonEquation::setMatrixTriplets(
             }
 
             if (neighbor.distance < re) {
-                double coefficient_ij = a * weight(neighbor.distance, re) / fluidDensity;
+                double coefficient_ij = a * weight(neighbor.distance, re) / pi.density;
                 matrixTriplets.emplace_back(pi.id, pj.id, -1.0 * coefficient_ij);
                 coefficient_ii += coefficient_ij;
             }

--- a/src/pressure_calculator/pressure_poisson_equation.hpp
+++ b/src/pressure_calculator/pressure_poisson_equation.hpp
@@ -19,7 +19,6 @@ public:
         int dimension,
         double dt,
         double relaxationCoefficient,
-        double fluidDensity,
         double compressibility,
         double n0_forNumberDensity,
         double n0_forLaplacian,
@@ -46,7 +45,6 @@ private:
     int dimension;
     double dt;
     double relaxationCoefficient;
-    double fluidDensity;
     double compressibility;
     double n0_forNumberDensity;
     double n0_forLaplacian;

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -26,7 +26,7 @@ struct Settings {
 
     // physical properties
     double kinematicViscosity{}; ///< Kinematic viscosity
-    double fluidDensity{};       ///< Fluid density
+    double defaultDensity{};     ///< default density for fluid and wall particles.
 
     // gravity
     Eigen::Vector3d gravity; ///< Gravity

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -58,7 +58,6 @@ Simulation::Simulation(fs::path& settingPath, fs::path& outputDirectory) {
             input.settings.re_forNumberDensity,
             input.settings.re_forLaplacian,
             input.settings.dt,
-            input.settings.fluidDensity,
             input.settings.compressibility,
             input.settings.relaxationCoefficientForPressure,
             std::move(DirichletBoundaryConditionGenerator)
@@ -66,7 +65,6 @@ Simulation::Simulation(fs::path& settingPath, fs::path& outputDirectory) {
 
     } else if (input.settings.pressureCalculationMethod == "Explicit") {
         pressureCalculator.reset(new PressureCalculator::Explicit(
-            input.settings.fluidDensity,
             input.settings.re_forNumberDensity,
             input.settings.soundSpeed,
             input.settings.dim,


### PR DESCRIPTION
Particle クラスに density をもたせるようにした。これにより、密度の違う複数流体の計算ができるようになった。
動画は Rayleigh-Taylor Instability の例。

https://github.com/MPS-Basic/MPS-Basic/assets/22005409/eb3c2776-0486-4b70-b320-ee3e057ce679


