### PR TITLE
update: checkout v3 to v4

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -10,7 +10,7 @@ jobs:
   cpp-linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: cpp-linter/cpp-linter-action@v2
         id: linter
         env:


### PR DESCRIPTION
- [actions/checkout](https://github.com/actions/checkout)をv3からv4に変えた