### PR TITLE
Add scripts/safe_runner.sh

### DIFF
--- a/scripts/safe_runner.sh
+++ b/scripts/safe_runner.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# Runner that seplates the result into a new folder with a timestamp
+
+# set variables
+projectName="dambreak"
+inputDir="input/${projectName}"
+settingFile="${inputDir}/settings.yml"
+
+timestamp=$(date +%Y%m%d%H%M%S)
+outputDir="result/${timestamp}"
+errorLogFile="${outputDir}/error.log"
+consoleLogFile="${outputDir}/console.log"
+
+# go to root directory so that we can activate the script from any directory
+cd $(dirname $0)/..
+
+# create output directory if not exist
+mkdir -p ${outputDir}
+
+# run simulation
+./build/mps --setting ${settingFile} --output ${outputDir} 2> ${errorLogFile} | tee ${consoleLogFile}

--- a/scripts/safe_runner.sh
+++ b/scripts/safe_runner.sh
@@ -7,7 +7,7 @@ inputDir="input/${projectName}"
 settingFile="${inputDir}/settings.yml"
 
 timestamp=$(date +%Y%m%d%H%M%S)
-outputDir="result/${timestamp}"
+outputDir="result/${timestamp}-${projectName}"
 errorLogFile="${outputDir}/error.log"
 consoleLogFile="${outputDir}/console.log"
 


### PR DESCRIPTION
This pull request introduces a new script, `safe_runner.sh`, for running simulations and organizing the results into timestamped folders.

* Added `safe_runner.sh` script to run simulations and separate results into a new folder with a timestamp.