### PR TITLE
add gravity input option; can choose direct xyz input or designating norm and angle

### DIFF
--- a/input/dambreak/settings.yml
+++ b/input/dambreak/settings.yml
@@ -16,7 +16,12 @@ defaultDensity: 1000.0 # If the particle density is not specified, this value is
 kinematicViscosity: 1.0e-06 # 少数第一位まで書かないと文字列として認識されてしまう
 
 # gravity
-gravity: [0.0, -9.8, 0.0]
+direct-input: true # direct input OR designate norm and angle
+# direct input
+gravity-direct-input: [0.0, -9.8, 0.0]
+# designate norm and angle, in XY plane ONLY
+gravity-norm: 9.8
+gravity-angle: 0 # in degrees, counter-clockwise from -Y direction
 
 # free surface detection
 # surface detection based on number density

--- a/input/hydrostatic/settings.yml
+++ b/input/hydrostatic/settings.yml
@@ -16,7 +16,12 @@ defaultDensity: 1000.0 # If the particle density is not specified, this value is
 kinematicViscosity: 1.0e-04 # 少数第一位まで書かないと文字列として認識されてしまう
 
 # gravity
-gravity: [0.0, -10.0, 0.0]
+direct-input: true # direct xyz input OR designate norm and angle
+# direct input
+gravity-direct-input: [0.0, -9.8, 0.0]
+# designate norm and angle, in XY plane ONLY
+gravity-norm: 9.8
+gravity-angle: 0 # in degrees, counter-clockwise from -Y direction
 
 # free surface detection
 # surface detection based on number density

--- a/src/loader.cpp
+++ b/src/loader.cpp
@@ -83,9 +83,12 @@ Settings Loader::loadSettingYaml(const fs::path& settingPath) {
     s.kinematicViscosity = yaml["kinematicViscosity"].as<double>();
 
     // gravity
-    s.gravity[0] = yaml["gravity"][0].as<double>();
-    s.gravity[1] = yaml["gravity"][1].as<double>();
-    s.gravity[2] = yaml["gravity"][2].as<double>();
+    s.directInput = yaml["direct-input"].as<bool>();
+    s.gDirectInput[0] = yaml["gravity-direct-input"][0].as<double>();
+    s.gDirectInput[1] = yaml["gravity-direct-input"][1].as<double>();
+    s.gDirectInput[2] = yaml["gravity-direct-input"][2].as<double>();
+    s.gNorm  = yaml["gravity-norm"].as<double>();
+    s.gAngle = yaml["gravity-angle"].as<double>();
 
     // free surface detection
     s.surfaceDetection_numberDensity_threshold = yaml["surfaceDetection-numberDensity-threshold"].as<double>();

--- a/src/settings.hpp
+++ b/src/settings.hpp
@@ -29,7 +29,10 @@ struct Settings {
     double defaultDensity{};     ///< default density for fluid and wall particles.
 
     // gravity
-    Eigen::Vector3d gravity; ///< Gravity
+    bool directInput;
+    Eigen::Vector3d gDirectInput; ///< Gravity vector when using direct input
+    double gNorm;                 ///< Norm of gravity when using norm and angle
+    double gAngle;                ///< Angle of gravity when using norm and angle
 
     // free surface detection
     // surface detection based on number density


### PR DESCRIPTION
This pull request introduces changes to support two methods for defining gravity in the simulation: direct input of the gravity vector and specifying gravity using its norm and angle. The updates include modifications to configuration files, the settings structure, and the gravity calculation logic in the simulation code.